### PR TITLE
feat: GitHub PR review support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,10 +1,15 @@
-name: Release
+name: Create Release
 
 on:
   pull_request:
     types:
       - closed
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 1.3.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,41 +17,25 @@ permissions:
 
 jobs:
   release:
-    if: "${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
+    if: "${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')) }}"
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
-      - name: Extract version from PR title
+      - uses: georgeguimaraes/workflows/actions/extract-version@main
         id: version
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'release \K[0-9]+\.[0-9]+\.[0-9]+')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+        with:
+          version: ${{ inputs.version }}
+          pr-title: ${{ github.event.pull_request.title }}
 
-      - name: Create tag
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
+      - uses: georgeguimaraes/workflows/actions/create-release@main
+        with:
+          version: ${{ steps.version.outputs.version }}
 
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: gh release create "$TAG" --generate-notes
-
-      - name: Mark release PR as tagged
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr edit "$PR_NUMBER" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
+      - uses: georgeguimaraes/workflows/actions/mark-release-tagged@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,10 +11,4 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: googleapis/release-please-action@v4
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-          skip-github-release: true
+    uses: georgeguimaraes/workflows/.github/workflows/release-please.yml@main

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Using lazy.nvim:
 | Key | Action |
 |-----|--------|
 | `gC` | Show GitHub thread at cursor |
-| `gn` | Start new GitHub thread at cursor |
+| `ga` | Start new GitHub thread at cursor |
 | `gS` | Start GitHub suggestion (one-click apply) |
-| `gn` (visual) | Multi-line comment on selection |
+| `ga` (visual) | Multi-line comment on selection |
 | `gS` (visual) | Multi-line suggestion on selection |
 | `gp` | Show PR description |
 | `]t` | Jump to next GitHub thread |
@@ -225,16 +225,16 @@ Existing PR comments show as purple `◆` signs (or gray `✓` if resolved). Pre
 
 ### Starting New Threads
 
-Use `gn` to start a new comment thread at the cursor line, or `gS` to start a code suggestion (uses GitHub's suggestion syntax for one-click apply).
+Use `ga` to start a new comment thread at the cursor line, or `gS` to start a code suggestion (uses GitHub's suggestion syntax for one-click apply).
 
 ### Multi-line Comments
 
-Select lines in visual mode, then press `gn` for a multi-line comment or `gS` for a multi-line suggestion. GitHub will highlight the entire range in the PR.
+Select lines in visual mode, then press `ga` for a multi-line comment or `gS` for a multi-line suggestion. GitHub will highlight the entire range in the PR.
 
 ### Quick vs Batch Review
 
 Two workflows are supported:
-- **Quick ad-hoc comments**: Use `gn`/`gS` to post comments immediately to GitHub
+- **Quick ad-hoc comments**: Use `ga`/`gS` to post comments immediately to GitHub
 - **Batch review**: Use `i` to add local annotations, then `gs` to submit them all as a single review
 
 ### Submitting Reviews

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Inspired by [tuicr](https://github.com/agavra/tuicr).
 - Export format optimized for AI conversations
 - Send comments directly to [sidekick.nvim](https://github.com/folke/sidekick.nvim) for AI chat
 - Commit picker modal to select specific commits to review
-- **GitHub PR review support**: checkout PRs, view existing comments, submit reviews
+- **GitHub PR review support**: checkout PRs, view/reply to threads, start new comments, submit reviews
+  - PR picker with search filtering
+  - View existing review threads with full conversation history
+  - Start new threads or code suggestions (single-line and multi-line)
+  - Reply, resolve/unresolve, edit, delete comments
+  - Add reactions to comments
+  - Open PR in browser
 - Built on top of codediff.nvim
 
 ## Requirements
@@ -94,6 +100,7 @@ Using lazy.nvim:
 | `]t` | Jump to next GitHub thread |
 | `[t` | Jump to previous GitHub thread |
 | `gs` | Submit review to GitHub |
+| `go` | Open PR in browser |
 
 **Thread popup keymaps** (when viewing a thread with `gC`):
 | Key | Action |
@@ -168,6 +175,30 @@ Comment types: ISSUE (problems to fix), SUGGESTION (improvements), NOTE (observa
 
 review.nvim can review GitHub PRs directly. It uses the `gh` CLI to checkout PRs, fetch existing review threads, and submit reviews.
 
+### Why review.nvim over octo.nvim?
+
+[octo.nvim](https://github.com/pwntester/octo.nvim) is a full-featured GitHub client. review.nvim takes a different approach:
+
+| | review.nvim | octo.nvim |
+|---|---|---|
+| **Focus** | Code review workflow | Full GitHub client |
+| **Diff view** | codediff.nvim (side-by-side, syntax highlighting) | Custom buffer |
+| **Dependencies** | nui.nvim + `gh` CLI | telescope, plenary, devicons |
+| **AI integration** | Export to clipboard/sidekick for AI feedback | None |
+| **Local annotations** | Yes (batch review workflow) | No |
+| **Issues, PRs, gists** | PRs only | Full support |
+
+**Choose review.nvim if you:**
+- Want a focused code review experience with proper side-by-side diffs
+- Use AI assistants (Claude, ChatGPT) in your review workflow
+- Prefer minimal dependencies (nui.nvim + `gh` CLI)
+- Want to batch annotations locally before submitting
+
+**Choose octo.nvim if you:**
+- Need full GitHub management (issues, PRs, gists, etc.)
+- Want to manage PR metadata (labels, assignees, milestones)
+- Prefer telescope-based navigation
+
 ### Setup
 
 1. Install [GitHub CLI](https://cli.github.com/)
@@ -176,9 +207,11 @@ review.nvim can review GitHub PRs directly. It uses the `gh` CLI to checkout PRs
 ### Workflow
 
 ```vim
-:Review PR           " Pick from open PRs
-:Review PR 123       " Open specific PR
+:Review PR           " Pick from open PRs (with search)
+:Review PR 123       " Open specific PR by number
 ```
+
+The PR picker supports filtering: just type to search by PR number, title, branch name, or author.
 
 This will:
 1. Checkout the PR branch
@@ -190,9 +223,19 @@ This will:
 
 Existing PR comments show as purple `◆` signs (or gray `✓` if resolved). Press `gC` to view the full thread with all replies and reactions. From the thread popup you can reply, resolve/unresolve, edit or delete your comments, and add reactions.
 
+### Starting New Threads
+
+Use `gn` to start a new comment thread at the cursor line, or `gS` to start a code suggestion (uses GitHub's suggestion syntax for one-click apply).
+
 ### Multi-line Comments
 
 Select lines in visual mode, then press `gn` for a multi-line comment or `gS` for a multi-line suggestion. GitHub will highlight the entire range in the PR.
+
+### Quick vs Batch Review
+
+Two workflows are supported:
+- **Quick ad-hoc comments**: Use `gn`/`gS` to post comments immediately to GitHub
+- **Batch review**: Use `i` to add local annotations, then `gs` to submit them all as a single review
 
 ### Submitting Reviews
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Inspired by [tuicr](https://github.com/agavra/tuicr).
 - Export format optimized for AI conversations
 - Send comments directly to [sidekick.nvim](https://github.com/folke/sidekick.nvim) for AI chat
 - Commit picker modal to select specific commits to review
+- **GitHub PR review support**: checkout PRs, view existing comments, submit reviews
 - Built on top of codediff.nvim
 
 ## Requirements
@@ -21,6 +22,7 @@ Inspired by [tuicr](https://github.com/agavra/tuicr).
 - Neovim >= 0.9
 - [codediff.nvim](https://github.com/esmuellert/codediff.nvim)
 - [nui.nvim](https://github.com/MunifTanjim/nui.nvim)
+- [GitHub CLI](https://cli.github.com/) (optional, for PR reviews)
 
 ## Installation
 
@@ -48,6 +50,9 @@ Using lazy.nvim:
 :Review              " Open codediff with comment keymaps (default)
 :Review open         " Same as above
 :Review commits      " Select commits to review (picker modal)
+:Review PR           " Review a GitHub PR (opens picker)
+:Review PR 123       " Review specific PR by number
+:Review submit       " Submit review to GitHub
 :Review close        " Close and export comments to clipboard
 :Review export       " Export comments to clipboard
 :Review preview      " Preview exported markdown in split
@@ -76,6 +81,16 @@ Using lazy.nvim:
 | `S` | Send comments to sidekick.nvim |
 | `<C-r>` | Clear all comments |
 | `q` | Close and export comments to clipboard |
+
+**GitHub PR keymaps** (when reviewing a PR):
+| Key | Action |
+|-----|--------|
+| `gC` | Show GitHub thread at cursor |
+| `gn` | Start new GitHub thread at cursor |
+| `gS` | Start GitHub suggestion (one-click apply) |
+| `]t` | Jump to next GitHub thread |
+| `[t` | Jump to previous GitHub thread |
+| `gs` | Submit review to GitHub |
 
 **Edit mode** (when `readonly = false`):
 | Key | Action |
@@ -135,6 +150,46 @@ Comment types: ISSUE (problems to fix), SUGGESTION (improvements), NOTE (observa
 2. **[SUGGESTION]** `src/utils/api.ts:45` - Consider using useMemo here
 3. **[PRAISE]** `src/hooks/useAuth.ts:12` - Clean implementation of the auth flow
 ```
+
+## GitHub PR Review
+
+review.nvim can review GitHub PRs directly. It uses the `gh` CLI to checkout PRs, fetch existing review threads, and submit reviews.
+
+### Setup
+
+1. Install [GitHub CLI](https://cli.github.com/)
+2. Authenticate: `gh auth login`
+
+### Workflow
+
+```vim
+:Review PR           " Pick from open PRs
+:Review PR 123       " Open specific PR
+```
+
+This will:
+1. Checkout the PR branch
+2. Open codediff with the correct diff (merge-base to head)
+3. Fetch and display existing GitHub review threads
+4. Let you add your own annotations
+
+### Viewing GitHub Threads
+
+Existing PR comments show as purple `◆` signs (or gray `✓` if resolved). Press `gC` to view the full thread with all replies and reactions.
+
+### Submitting Reviews
+
+After adding your annotations, press `gs` or run `:Review submit`:
+
+1. Preview your comments
+2. Choose review type: Approve (`a`), Comment (`c`), or Request Changes (`r`)
+3. Add an optional summary
+4. Comments are submitted as a PR review
+
+Your local comment types map to GitHub:
+- **Issue** → suggests "Request Changes"
+- **Suggestion/Note** → suggests "Comment"
+- **Praise** → suggests "Approve"
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,22 @@ Using lazy.nvim:
 | `gC` | Show GitHub thread at cursor |
 | `gn` | Start new GitHub thread at cursor |
 | `gS` | Start GitHub suggestion (one-click apply) |
+| `gn` (visual) | Multi-line comment on selection |
+| `gS` (visual) | Multi-line suggestion on selection |
+| `gp` | Show PR description |
 | `]t` | Jump to next GitHub thread |
 | `[t` | Jump to previous GitHub thread |
 | `gs` | Submit review to GitHub |
+
+**Thread popup keymaps** (when viewing a thread with `gC`):
+| Key | Action |
+|-----|--------|
+| `r` | Reply to thread |
+| `R` | Toggle resolved status |
+| `e` | Edit your last comment |
+| `d` | Delete your last comment |
+| `+` | Add reaction to last comment |
+| `q` | Close popup |
 
 **Edit mode** (when `readonly = false`):
 | Key | Action |
@@ -175,7 +188,11 @@ This will:
 
 ### Viewing GitHub Threads
 
-Existing PR comments show as purple `◆` signs (or gray `✓` if resolved). Press `gC` to view the full thread with all replies and reactions.
+Existing PR comments show as purple `◆` signs (or gray `✓` if resolved). Press `gC` to view the full thread with all replies and reactions. From the thread popup you can reply, resolve/unresolve, edit or delete your comments, and add reactions.
+
+### Multi-line Comments
+
+Select lines in visual mode, then press `gn` for a multi-line comment or `gS` for a multi-line suggestion. GitHub will highlight the entire range in the PR.
 
 ### Submitting Reviews
 

--- a/lua/review/github/api.lua
+++ b/lua/review/github/api.lua
@@ -1,0 +1,321 @@
+local M = {}
+
+---Check if gh CLI is available
+---@return boolean
+function M.is_available()
+  return vim.fn.executable("gh") == 1
+end
+
+---Check if authenticated with GitHub
+---@return boolean
+function M.is_authenticated()
+  local result = vim.fn.system("gh auth status 2>&1")
+  return vim.v.shell_error == 0
+end
+
+---Get current repo info from git remote
+---@return { owner: string, repo: string }|nil
+function M.get_repo_info()
+  local result = vim.fn.system("gh repo view --json owner,name -q '.owner.login + \"/\" + .name'")
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+  local parts = vim.split(vim.trim(result), "/")
+  if #parts ~= 2 then
+    return nil
+  end
+  return { owner = parts[1], repo = parts[2] }
+end
+
+---List open PRs
+---@param opts? { limit?: number, state?: string }
+---@return table[]|nil
+function M.list_prs(opts)
+  opts = opts or {}
+  local limit = opts.limit or 30
+  local state = opts.state or "open"
+
+  local cmd = string.format(
+    "gh pr list --limit %d --state %s --json number,title,author,headRefName,baseRefName,createdAt,isDraft",
+    limit,
+    state
+  )
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+
+  local ok, prs = pcall(vim.json.decode, result)
+  if not ok then
+    return nil
+  end
+  return prs
+end
+
+---Get PR details
+---@param number number PR number
+---@return PRContext|nil
+function M.get_pr(number)
+  local cmd = string.format(
+    "gh pr view %d --json number,title,author,baseRefName,baseRefOid,headRefName,headRefOid,url",
+    number
+  )
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+
+  local ok, pr = pcall(vim.json.decode, result)
+  if not ok then
+    return nil
+  end
+
+  local repo_info = M.get_repo_info()
+  if not repo_info then
+    return nil
+  end
+
+  return {
+    number = pr.number,
+    owner = repo_info.owner,
+    repo = repo_info.repo,
+    title = pr.title,
+    author = pr.author.login,
+    base_ref = pr.baseRefName,
+    head_ref = pr.headRefName,
+    base_sha = pr.baseRefOid,
+    head_sha = pr.headRefOid,
+    url = pr.url,
+    merge_base = nil, -- filled in by get_merge_base
+  }
+end
+
+---Checkout PR branch
+---@param number number PR number
+---@return boolean success
+---@return string? error
+function M.checkout_pr(number)
+  local result = vim.fn.system(string.format("gh pr checkout %d 2>&1", number))
+  if vim.v.shell_error ~= 0 then
+    return false, vim.trim(result)
+  end
+  return true, nil
+end
+
+---Get merge-base between two refs
+---@param base string Base ref
+---@param head string Head ref
+---@return string|nil
+function M.get_merge_base(base, head)
+  local cmd = string.format("git merge-base %s %s", vim.fn.shellescape(base), vim.fn.shellescape(head))
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+  return vim.trim(result)
+end
+
+---Fetch review threads for a PR using GraphQL
+---@param number number PR number
+---@return GitHubThread[]|nil
+function M.get_review_threads(number)
+  local repo_info = M.get_repo_info()
+  if not repo_info then
+    return nil
+  end
+
+  local query = [[
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          path
+          line
+          startLine
+          diffSide
+          isResolved
+          isOutdated
+          comments(first: 50) {
+            nodes {
+              id
+              body
+              author { login }
+              createdAt
+              reactionGroups {
+                content
+                users { totalCount }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+]]
+
+  local variables = vim.json.encode({
+    owner = repo_info.owner,
+    repo = repo_info.repo,
+    number = number,
+  })
+
+  local cmd = string.format(
+    "gh api graphql -f query=%s -f variables=%s",
+    vim.fn.shellescape(query),
+    vim.fn.shellescape(variables)
+  )
+
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+
+  local ok, data = pcall(vim.json.decode, result)
+  if not ok or not data.data then
+    return nil
+  end
+
+  local threads = {}
+  local nodes = data.data.repository.pullRequest.reviewThreads.nodes or {}
+
+  for _, node in ipairs(nodes) do
+    local comments = {}
+    for _, c in ipairs(node.comments.nodes or {}) do
+      local reactions = {}
+      for _, rg in ipairs(c.reactionGroups or {}) do
+        if rg.users.totalCount > 0 then
+          reactions[rg.content] = rg.users.totalCount
+        end
+      end
+      table.insert(comments, {
+        id = c.id,
+        author = c.author and c.author.login or "ghost",
+        body = c.body,
+        created_at = c.createdAt,
+        reactions = reactions,
+      })
+    end
+
+    table.insert(threads, {
+      id = node.id,
+      path = node.path,
+      line = node.line,
+      start_line = node.startLine,
+      side = node.diffSide,
+      is_resolved = node.isResolved,
+      is_outdated = node.isOutdated,
+      comments = comments,
+    })
+  end
+
+  return threads
+end
+
+---Submit a review
+---@param pr_id string PR node ID
+---@param event "APPROVE"|"REQUEST_CHANGES"|"COMMENT"
+---@param body? string Overall review body
+---@param comments? { path: string, line: number, body: string }[]
+---@return boolean success
+---@return string? error
+function M.submit_review(pr_id, event, body, comments)
+  local mutation = [[
+mutation($input: AddPullRequestReviewInput!) {
+  addPullRequestReview(input: $input) {
+    pullRequestReview {
+      id
+      state
+    }
+  }
+}
+]]
+
+  local input = {
+    pullRequestId = pr_id,
+    event = event,
+  }
+  if body and body ~= "" then
+    input.body = body
+  end
+  if comments and #comments > 0 then
+    input.comments = comments
+  end
+
+  local variables = vim.json.encode({ input = input })
+  local cmd = string.format(
+    "gh api graphql -f query=%s -f variables=%s",
+    vim.fn.shellescape(mutation),
+    vim.fn.shellescape(variables)
+  )
+
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return false, vim.trim(result)
+  end
+
+  return true, nil
+end
+
+---Get PR node ID (needed for mutations)
+---@param number number PR number
+---@return string|nil
+function M.get_pr_node_id(number)
+  local cmd = string.format("gh pr view %d --json id -q .id", number)
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+  return vim.trim(result)
+end
+
+---Start a new review thread on a specific line
+---@param pr_id string PR node ID
+---@param path string File path relative to repo root
+---@param line number Line number in the diff
+---@param body string Comment body
+---@param side? "LEFT"|"RIGHT" Diff side (default RIGHT for new changes)
+---@return boolean success
+---@return string? error
+function M.add_review_thread(pr_id, path, line, body, side)
+  local mutation = [[
+mutation($input: AddPullRequestReviewInput!) {
+  addPullRequestReview(input: $input) {
+    pullRequestReview {
+      id
+    }
+  }
+}
+]]
+
+  local input = {
+    pullRequestId = pr_id,
+    event = "COMMENT",
+    comments = {
+      {
+        path = path,
+        line = line,
+        side = side or "RIGHT",
+        body = body,
+      },
+    },
+  }
+
+  local variables = vim.json.encode({ input = input })
+  local cmd = string.format(
+    "gh api graphql -f query=%s -f variables=%s",
+    vim.fn.shellescape(mutation),
+    vim.fn.shellescape(variables)
+  )
+
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    return false, vim.trim(result)
+  end
+
+  return true, nil
+end
+
+return M

--- a/lua/review/github/init.lua
+++ b/lua/review/github/init.lua
@@ -1,0 +1,131 @@
+local M = {}
+
+local api = require("review.github.api")
+local picker = require("review.github.picker")
+
+---@class PRContext
+---@field number number PR number
+---@field owner string Repository owner
+---@field repo string Repository name
+---@field title string PR title
+---@field author string PR author
+---@field base_ref string Base branch name
+---@field head_ref string Head branch name
+---@field base_sha string Base commit SHA
+---@field head_sha string Head commit SHA
+---@field merge_base string Merge-base commit SHA
+---@field url string PR URL
+
+---@type PRContext|nil
+M.current_pr = nil
+
+---Open a PR for review
+---@param number? number PR number (opens picker if nil)
+function M.open(number)
+  if not api.is_available() then
+    vim.notify("gh CLI not found. Install from https://cli.github.com", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  if not api.is_authenticated() then
+    vim.notify("Not authenticated with GitHub. Run: gh auth login", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  if number then
+    M._open_pr(number)
+  else
+    picker.open(function(pr_number)
+      M._open_pr(pr_number)
+    end)
+  end
+end
+
+---Internal: open PR by number
+---@param number number
+function M._open_pr(number)
+  vim.notify(string.format("Loading PR #%d...", number), vim.log.levels.INFO, { title = "Review" })
+
+  -- Get PR details
+  local pr = api.get_pr(number)
+  if not pr then
+    vim.notify(string.format("Failed to fetch PR #%d", number), vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  -- Checkout PR branch
+  vim.notify(string.format("Checking out PR #%d...", number), vim.log.levels.INFO, { title = "Review" })
+  local ok, err = api.checkout_pr(number)
+  if not ok then
+    vim.notify(string.format("Failed to checkout PR: %s", err or "unknown error"), vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  -- Calculate merge-base for accurate diff
+  local merge_base = api.get_merge_base("origin/" .. pr.base_ref, "HEAD")
+  if not merge_base then
+    -- Fallback to base SHA if merge-base fails
+    merge_base = pr.base_sha
+  end
+  pr.merge_base = merge_base
+
+  -- Store current PR context
+  M.current_pr = pr
+
+  -- Load review.nvim store
+  local store = require("review.store")
+  store.load()
+
+  -- Open codediff with the correct refs
+  local codediff_ok, _ = pcall(require, "codediff")
+  if not codediff_ok then
+    vim.notify("codediff.nvim is required", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  vim.cmd(string.format("CodeDiff %s %s", merge_base, pr.head_sha))
+
+  -- Set up review.nvim hooks after codediff initializes
+  vim.defer_fn(function()
+    local review = require("review")
+    review._check_codediff_session()
+
+    -- Fetch and display GitHub threads
+    local threads = require("review.github.threads")
+    vim.notify("Fetching PR comments...", vim.log.levels.INFO, { title = "Review" })
+    if threads.fetch(pr.number) then
+      local thread_count = #threads.threads
+      threads.render_all()
+      vim.notify(
+        string.format("Reviewing PR #%d: %s (%d threads)", pr.number, pr.title, thread_count),
+        vim.log.levels.INFO,
+        { title = "Review" }
+      )
+    else
+      vim.notify(
+        string.format("Reviewing PR #%d: %s", pr.number, pr.title),
+        vim.log.levels.INFO,
+        { title = "Review" }
+      )
+    end
+  end, 300)
+end
+
+---Get current PR context
+---@return PRContext|nil
+function M.get_current_pr()
+  return M.current_pr
+end
+
+---Check if currently reviewing a PR
+---@return boolean
+function M.is_pr_review()
+  return M.current_pr ~= nil
+end
+
+---Clear current PR context
+function M.clear()
+  M.current_pr = nil
+end
+
+return M

--- a/lua/review/github/picker.lua
+++ b/lua/review/github/picker.lua
@@ -4,9 +4,13 @@ local Popup = require("nui.popup")
 local api = require("review.github.api")
 
 ---@type table[]
-local prs = {}
+local all_prs = {}
+---@type table[]
+local filtered_prs = {}
 ---@type any
 local popup = nil
+---@type string
+local search_query = ""
 
 local function format_line(pr)
   local draft = pr.isDraft and "[draft] " or ""
@@ -25,6 +29,29 @@ local function format_line(pr)
   return line
 end
 
+local function filter_prs()
+  if search_query == "" then
+    filtered_prs = all_prs
+    return
+  end
+
+  local query = search_query:lower()
+  filtered_prs = {}
+  for _, pr in ipairs(all_prs) do
+    local searchable = string.format(
+      "#%d %s %s %s %s",
+      pr.number,
+      pr.title,
+      pr.headRefName,
+      pr.baseRefName,
+      pr.author.login
+    ):lower()
+    if searchable:find(query, 1, true) then
+      table.insert(filtered_prs, pr)
+    end
+  end
+end
+
 local function render_lines()
   if not popup then
     return
@@ -33,13 +60,36 @@ local function render_lines()
   local buf = popup.bufnr
   local lines = {}
 
-  for _, pr in ipairs(prs) do
+  -- Search prompt line
+  local prompt = "/ " .. search_query
+  if search_query == "" then
+    prompt = "/ (type to search)"
+  end
+  table.insert(lines, prompt)
+  table.insert(lines, string.rep("─", 60))
+
+  for _, pr in ipairs(filtered_prs) do
     table.insert(lines, format_line(pr))
+  end
+
+  if #filtered_prs == 0 and #all_prs > 0 then
+    table.insert(lines, "  (no matches)")
   end
 
   vim.api.nvim_set_option_value("modifiable", true, { buf = buf })
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+
+  -- Highlight search line
+  local ns_id = vim.api.nvim_create_namespace("review_pr_picker")
+  vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
+  vim.api.nvim_buf_add_highlight(buf, ns_id, "Comment", 0, 0, -1)
+  vim.api.nvim_buf_add_highlight(buf, ns_id, "Comment", 1, 0, -1)
+
+  -- Position cursor on first PR (line 3)
+  if #filtered_prs > 0 then
+    pcall(vim.api.nvim_win_set_cursor, popup.winid, { 3, 0 })
+  end
 end
 
 local function close_picker()
@@ -47,18 +97,42 @@ local function close_picker()
     popup:unmount()
     popup = nil
   end
-  prs = {}
+  all_prs = {}
+  filtered_prs = {}
+  search_query = ""
 end
 
 local function confirm_selection(callback)
   local cursor = vim.api.nvim_win_get_cursor(0)
   local line_num = cursor[1]
-  local pr = prs[line_num]
+  -- Subtract 2 for search prompt and separator
+  local pr_idx = line_num - 2
+  local pr = filtered_prs[pr_idx]
   close_picker()
 
   if pr then
     callback(pr.number)
   end
+end
+
+local function handle_char(char)
+  search_query = search_query .. char
+  filter_prs()
+  render_lines()
+end
+
+local function handle_backspace()
+  if #search_query > 0 then
+    search_query = search_query:sub(1, -2)
+    filter_prs()
+    render_lines()
+  end
+end
+
+local function clear_search()
+  search_query = ""
+  filter_prs()
+  render_lines()
 end
 
 ---Open PR picker
@@ -76,15 +150,17 @@ function M.open(callback)
 
   vim.notify("Fetching PRs...", vim.log.levels.INFO, { title = "Review" })
 
-  prs = api.list_prs({ limit = 30 }) or {}
+  all_prs = api.list_prs({ limit = 50 }) or {}
+  search_query = ""
+  filter_prs()
 
-  if #prs == 0 then
+  if #all_prs == 0 then
     vim.notify("No open PRs found", vim.log.levels.WARN, { title = "Review" })
     return
   end
 
   local width = math.min(120, vim.o.columns - 10)
-  local height = math.min(20, #prs + 2, vim.o.lines - 10)
+  local height = math.min(25, #all_prs + 4, vim.o.lines - 10)
 
   popup = Popup({
     position = "50%",
@@ -97,7 +173,7 @@ function M.open(callback)
       text = {
         top = " Select PR to review ",
         top_align = "center",
-        bottom = " <CR> select | q quit ",
+        bottom = " <CR> select | <C-u> clear | q quit ",
         bottom_align = "center",
       },
     },
@@ -119,6 +195,15 @@ function M.open(callback)
   popup:map("n", "<CR>", function() confirm_selection(callback) end, map_opts)
   popup:map("n", "q", close_picker, map_opts)
   popup:map("n", "<Esc>", close_picker, map_opts)
+  popup:map("n", "<C-u>", clear_search, map_opts)
+  popup:map("n", "<BS>", handle_backspace, map_opts)
+
+  -- Map printable characters for search
+  local chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_@#"
+  for i = 1, #chars do
+    local char = chars:sub(i, i)
+    popup:map("n", char, function() handle_char(char) end, map_opts)
+  end
 end
 
 return M

--- a/lua/review/github/picker.lua
+++ b/lua/review/github/picker.lua
@@ -1,0 +1,124 @@
+local M = {}
+
+local Popup = require("nui.popup")
+local api = require("review.github.api")
+
+---@type table[]
+local prs = {}
+---@type any
+local popup = nil
+
+local function format_line(pr)
+  local draft = pr.isDraft and "[draft] " or ""
+  local line = string.format(
+    "#%-4d %s%s (%s → %s) @%s",
+    pr.number,
+    draft,
+    pr.title,
+    pr.headRefName,
+    pr.baseRefName,
+    pr.author.login
+  )
+  if #line > 120 then
+    line = line:sub(1, 117) .. "..."
+  end
+  return line
+end
+
+local function render_lines()
+  if not popup then
+    return
+  end
+
+  local buf = popup.bufnr
+  local lines = {}
+
+  for _, pr in ipairs(prs) do
+    table.insert(lines, format_line(pr))
+  end
+
+  vim.api.nvim_set_option_value("modifiable", true, { buf = buf })
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+end
+
+local function close_picker()
+  if popup then
+    popup:unmount()
+    popup = nil
+  end
+  prs = {}
+end
+
+local function confirm_selection(callback)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local line_num = cursor[1]
+  local pr = prs[line_num]
+  close_picker()
+
+  if pr then
+    callback(pr.number)
+  end
+end
+
+---Open PR picker
+---@param callback fun(pr_number: number)
+function M.open(callback)
+  if not api.is_available() then
+    vim.notify("gh CLI not found. Install from https://cli.github.com", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  if not api.is_authenticated() then
+    vim.notify("Not authenticated with GitHub. Run: gh auth login", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  vim.notify("Fetching PRs...", vim.log.levels.INFO, { title = "Review" })
+
+  prs = api.list_prs({ limit = 30 }) or {}
+
+  if #prs == 0 then
+    vim.notify("No open PRs found", vim.log.levels.WARN, { title = "Review" })
+    return
+  end
+
+  local width = math.min(120, vim.o.columns - 10)
+  local height = math.min(20, #prs + 2, vim.o.lines - 10)
+
+  popup = Popup({
+    position = "50%",
+    size = {
+      width = width,
+      height = height,
+    },
+    border = {
+      style = "rounded",
+      text = {
+        top = " Select PR to review ",
+        top_align = "center",
+        bottom = " <CR> select | q quit ",
+        bottom_align = "center",
+      },
+    },
+    buf_options = {
+      modifiable = false,
+      buftype = "nofile",
+    },
+    win_options = {
+      cursorline = true,
+    },
+  })
+
+  popup:mount()
+  render_lines()
+
+  vim.api.nvim_set_current_win(popup.winid)
+
+  local map_opts = { noremap = true, nowait = true }
+  popup:map("n", "<CR>", function() confirm_selection(callback) end, map_opts)
+  popup:map("n", "q", close_picker, map_opts)
+  popup:map("n", "<Esc>", close_picker, map_opts)
+end
+
+return M

--- a/lua/review/github/submit.lua
+++ b/lua/review/github/submit.lua
@@ -18,7 +18,7 @@ local type_to_event = {
 
 ---Convert local comments to GitHub review comments format
 ---@param comments table[]
----@return { path: string, line: number, body: string }[]
+---@return { path: string, line: number, side: string, body: string }[]
 local function convert_comments(comments)
   local github_comments = {}
 
@@ -29,6 +29,7 @@ local function convert_comments(comments)
     table.insert(github_comments, {
       path = comment.file,
       line = comment.line,
+      side = "RIGHT", -- Comments on new changes (HEAD side of the diff)
       body = prefix .. comment.text,
     })
   end
@@ -142,6 +143,9 @@ function M.show_submit_ui()
   })
 
   submit_popup:mount()
+
+  -- Ensure popup has focus
+  vim.api.nvim_set_current_win(submit_popup.winid)
 
   local buf = submit_popup.bufnr
   vim.api.nvim_set_option_value("modifiable", true, { buf = buf })

--- a/lua/review/github/submit.lua
+++ b/lua/review/github/submit.lua
@@ -1,0 +1,265 @@
+local M = {}
+
+local api = require("review.github.api")
+local Popup = require("nui.popup")
+local Input = require("nui.input")
+
+---@type any
+local submit_popup = nil
+
+---Map review.nvim comment types to GitHub review events
+---@type table<string, string>
+local type_to_event = {
+  issue = "REQUEST_CHANGES",
+  suggestion = "COMMENT",
+  note = "COMMENT",
+  praise = "APPROVE",
+}
+
+---Convert local comments to GitHub review comments format
+---@param comments table[]
+---@return { path: string, line: number, body: string }[]
+local function convert_comments(comments)
+  local github_comments = {}
+
+  for _, comment in ipairs(comments) do
+    local type_info = require("review.config").get().comment_types[comment.type]
+    local prefix = type_info and string.format("[%s] ", string.upper(type_info.name)) or ""
+
+    table.insert(github_comments, {
+      path = comment.file,
+      line = comment.line,
+      body = prefix .. comment.text,
+    })
+  end
+
+  return github_comments
+end
+
+---Determine the suggested review event based on comment types
+---@param comments table[]
+---@return string
+local function suggest_event(comments)
+  local has_issue = false
+  local has_praise = false
+
+  for _, comment in ipairs(comments) do
+    if comment.type == "issue" then
+      has_issue = true
+    elseif comment.type == "praise" then
+      has_praise = true
+    end
+  end
+
+  if has_issue then
+    return "REQUEST_CHANGES"
+  elseif has_praise and #comments == 1 then
+    return "APPROVE"
+  else
+    return "COMMENT"
+  end
+end
+
+---Show submit review UI
+function M.show_submit_ui()
+  local github = require("review.github")
+  local pr = github.get_current_pr()
+
+  if not pr then
+    vim.notify("No active PR review", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local store = require("review.store")
+  local comments = store.get_all()
+
+  if #comments == 0 then
+    vim.notify("No comments to submit", vim.log.levels.WARN, { title = "Review" })
+    return
+  end
+
+  -- Get PR node ID for mutation
+  local pr_node_id = api.get_pr_node_id(pr.number)
+  if not pr_node_id then
+    vim.notify("Failed to get PR ID", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local suggested = suggest_event(comments)
+
+  -- Build preview
+  local lines = {}
+  table.insert(lines, string.format("PR #%d: %s", pr.number, pr.title))
+  table.insert(lines, string.rep("─", 50))
+  table.insert(lines, "")
+  table.insert(lines, string.format("Comments to submit: %d", #comments))
+  table.insert(lines, "")
+
+  for _, comment in ipairs(comments) do
+    local type_info = require("review.config").get().comment_types[comment.type]
+    local icon = type_info and type_info.icon or "●"
+    local preview = comment.text:gsub("\n", " ")
+    if #preview > 40 then
+      preview = preview:sub(1, 37) .. "..."
+    end
+    table.insert(lines, string.format("  %s %s:%d - %s", icon, comment.file, comment.line, preview))
+  end
+
+  table.insert(lines, "")
+  table.insert(lines, string.rep("─", 50))
+  table.insert(lines, "")
+  table.insert(lines, "Review type:")
+  table.insert(lines, string.format("  [a] Approve%s", suggested == "APPROVE" and " (suggested)" or ""))
+  table.insert(lines, string.format("  [c] Comment%s", suggested == "COMMENT" and " (suggested)" or ""))
+  table.insert(lines, string.format("  [r] Request changes%s", suggested == "REQUEST_CHANGES" and " (suggested)" or ""))
+  table.insert(lines, "")
+  table.insert(lines, "  [q] Cancel")
+
+  local width = 60
+  local height = math.min(#lines + 2, vim.o.lines - 10)
+
+  if submit_popup then
+    submit_popup:unmount()
+  end
+
+  submit_popup = Popup({
+    position = "50%",
+    size = {
+      width = width,
+      height = height,
+    },
+    border = {
+      style = "rounded",
+      text = {
+        top = " Submit Review ",
+        top_align = "center",
+      },
+    },
+    buf_options = {
+      modifiable = false,
+      buftype = "nofile",
+    },
+  })
+
+  submit_popup:mount()
+
+  local buf = submit_popup.bufnr
+  vim.api.nvim_set_option_value("modifiable", true, { buf = buf })
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+
+  local map_opts = { noremap = true, nowait = true }
+
+  local function close()
+    submit_popup:unmount()
+    submit_popup = nil
+  end
+
+  local function submit_with_event(event)
+    close()
+    M._prompt_body_and_submit(pr_node_id, pr.number, event, comments)
+  end
+
+  submit_popup:map("n", "a", function() submit_with_event("APPROVE") end, map_opts)
+  submit_popup:map("n", "c", function() submit_with_event("COMMENT") end, map_opts)
+  submit_popup:map("n", "r", function() submit_with_event("REQUEST_CHANGES") end, map_opts)
+  submit_popup:map("n", "q", close, map_opts)
+  submit_popup:map("n", "<Esc>", close, map_opts)
+end
+
+---Prompt for review body and submit
+---@param pr_node_id string
+---@param pr_number number
+---@param event string
+---@param comments table[]
+function M._prompt_body_and_submit(pr_node_id, pr_number, event, comments)
+  local event_names = {
+    APPROVE = "Approve",
+    COMMENT = "Comment",
+    REQUEST_CHANGES = "Request changes",
+  }
+
+  vim.ui.input({
+    prompt = string.format("Review summary (%s): ", event_names[event] or event),
+  }, function(body)
+    if body == nil then
+      -- Cancelled
+      return
+    end
+
+    M._do_submit(pr_node_id, pr_number, event, body, comments)
+  end)
+end
+
+---Actually submit the review
+---@param pr_node_id string
+---@param pr_number number
+---@param event string
+---@param body string
+---@param comments table[]
+function M._do_submit(pr_node_id, pr_number, event, body, comments)
+  vim.notify("Submitting review...", vim.log.levels.INFO, { title = "Review" })
+
+  local github_comments = convert_comments(comments)
+
+  local ok, err = api.submit_review(pr_node_id, event, body, github_comments)
+
+  if not ok then
+    vim.notify("Failed to submit review: " .. (err or "unknown error"), vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local event_names = {
+    APPROVE = "approved",
+    COMMENT = "commented on",
+    REQUEST_CHANGES = "requested changes on",
+  }
+
+  vim.notify(
+    string.format("Successfully %s PR #%d with %d comment(s)", event_names[event] or "reviewed", pr_number, #comments),
+    vim.log.levels.INFO,
+    { title = "Review" }
+  )
+
+  -- Ask to clear local comments
+  vim.ui.select({ "Yes", "No" }, {
+    prompt = "Clear local comments?",
+  }, function(choice)
+    if choice == "Yes" then
+      local store = require("review.store")
+      store.clear()
+      require("review.marks").clear_all()
+      vim.notify("Local comments cleared", vim.log.levels.INFO, { title = "Review" })
+    end
+  end)
+end
+
+---Quick submit with suggested event (no UI)
+function M.quick_submit()
+  local github = require("review.github")
+  local pr = github.get_current_pr()
+
+  if not pr then
+    vim.notify("No active PR review", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local store = require("review.store")
+  local comments = store.get_all()
+
+  if #comments == 0 then
+    vim.notify("No comments to submit", vim.log.levels.WARN, { title = "Review" })
+    return
+  end
+
+  local pr_node_id = api.get_pr_node_id(pr.number)
+  if not pr_node_id then
+    vim.notify("Failed to get PR ID", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local event = suggest_event(comments)
+  M._prompt_body_and_submit(pr_node_id, pr.number, event, comments)
+end
+
+return M

--- a/lua/review/github/threads.lua
+++ b/lua/review/github/threads.lua
@@ -548,7 +548,7 @@ function M.prev_thread()
 
   -- Wrap to last
   if #threads > 0 then
-    vim.api.nvim_win_set_cursor(0, { threads[1].line, 0 })
+    vim.api.nvim_win_set_cursor(0, { threads[#threads].line, 0 })
   end
 end
 

--- a/lua/review/github/threads.lua
+++ b/lua/review/github/threads.lua
@@ -1,0 +1,641 @@
+local M = {}
+
+local api = require("review.github.api")
+local Popup = require("nui.popup")
+
+local ns_id = vim.api.nvim_create_namespace("review_github")
+
+---@class GitHubThread
+---@field id string Thread ID
+---@field path string File path
+---@field line number Line number
+---@field start_line number|nil Start line for multi-line comments
+---@field side "LEFT"|"RIGHT" Which side of diff
+---@field is_resolved boolean
+---@field is_outdated boolean
+---@field comments GitHubComment[]
+
+---@class GitHubComment
+---@field id string Comment ID
+---@field author string
+---@field body string
+---@field created_at string
+---@field reactions table<string, number>
+
+---@type GitHubThread[]
+M.threads = {}
+
+---@type table<string, GitHubThread[]> threads by file path
+M.threads_by_file = {}
+
+---@type any Current popup
+local thread_popup = nil
+
+---Fetch threads for a PR and store them
+---@param pr_number number
+---@return boolean success
+function M.fetch(pr_number)
+  local threads = api.get_review_threads(pr_number)
+  if not threads then
+    return false
+  end
+
+  M.threads = threads
+  M.threads_by_file = {}
+
+  for _, thread in ipairs(threads) do
+    if not M.threads_by_file[thread.path] then
+      M.threads_by_file[thread.path] = {}
+    end
+    table.insert(M.threads_by_file[thread.path], thread)
+  end
+
+  return true
+end
+
+---Clear stored threads
+function M.clear()
+  M.threads = {}
+  M.threads_by_file = {}
+end
+
+---Get threads for a specific file
+---@param file string
+---@return GitHubThread[]
+function M.get_for_file(file)
+  return M.threads_by_file[file] or {}
+end
+
+---Get thread at a specific line
+---@param file string
+---@param line number
+---@return GitHubThread|nil
+function M.get_at_line(file, line)
+  local threads = M.threads_by_file[file] or {}
+  for _, thread in ipairs(threads) do
+    if thread.line == line then
+      return thread
+    end
+  end
+  return nil
+end
+
+---Normalize path for matching
+---@param path string
+---@return string
+local function normalize_path(path)
+  if not path then
+    return path
+  end
+  path = path:gsub("^%./", "")
+  path = path:gsub("/+$", "")
+  return path
+end
+
+---Render GitHub threads for a buffer
+---@param bufnr number
+function M.render_for_buffer(bufnr)
+  if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local bufname = vim.api.nvim_buf_get_name(bufnr)
+  if not bufname or bufname == "" then
+    return
+  end
+
+  -- Extract file path
+  local file
+  if bufname:match("^codediff://") then
+    local path = bufname:match("^codediff://[^/]+/(.+)%?") or bufname:match("^codediff://[^/]+/(.+)$")
+    if path then
+      file = normalize_path(path)
+    end
+  else
+    file = normalize_path(vim.fn.fnamemodify(bufname, ":."))
+  end
+
+  if not file then
+    return
+  end
+
+  local threads = M.get_for_file(file)
+
+  -- Clear previous GitHub thread marks
+  vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+
+  for _, thread in ipairs(threads) do
+    local line = thread.line - 1
+    if line >= 0 then
+      local icon = thread.is_resolved and "✓" or "◆"
+      local hl = thread.is_resolved and "ReviewGitHubResolved" or "ReviewGitHubThread"
+      local line_hl = thread.is_outdated and "ReviewGitHubOutdated" or nil
+
+      -- Resolved threads: just show sign, no virtual text (collapsed)
+      if thread.is_resolved then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns_id, line, 0, {
+          sign_text = icon,
+          sign_hl_group = hl,
+          line_hl_group = line_hl,
+        })
+      else
+        -- Open threads: show preview text
+        local preview = ""
+        if thread.comments and #thread.comments > 0 then
+          local first = thread.comments[1]
+          local first_line = vim.split(first.body, "\n")[1] or ""
+          preview = string.format("@%s: %s", first.author, first_line)
+          if #preview > 60 then
+            preview = preview:sub(1, 57) .. "..."
+          end
+          if #thread.comments > 1 then
+            preview = preview .. string.format(" (+%d)", #thread.comments - 1)
+          end
+        end
+
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns_id, line, 0, {
+          sign_text = icon,
+          sign_hl_group = hl,
+          line_hl_group = line_hl,
+          virt_text = { { "  " .. preview, "ReviewGitHubVirtText" } },
+          virt_text_pos = "eol",
+        })
+      end
+    end
+  end
+end
+
+---Format relative time
+---@param iso_time string
+---@return string
+local function format_relative_time(iso_time)
+  -- Simple relative time formatting
+  local year, month, day, hour, min, sec = iso_time:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
+  if not year then
+    return iso_time
+  end
+
+  local then_time = os.time({
+    year = tonumber(year),
+    month = tonumber(month),
+    day = tonumber(day),
+    hour = tonumber(hour),
+    min = tonumber(min),
+    sec = tonumber(sec),
+  })
+
+  local diff = os.time() - then_time
+  if diff < 60 then
+    return "just now"
+  elseif diff < 3600 then
+    local mins = math.floor(diff / 60)
+    return mins == 1 and "1 minute ago" or mins .. " minutes ago"
+  elseif diff < 86400 then
+    local hours = math.floor(diff / 3600)
+    return hours == 1 and "1 hour ago" or hours .. " hours ago"
+  elseif diff < 604800 then
+    local days = math.floor(diff / 86400)
+    return days == 1 and "1 day ago" or days .. " days ago"
+  else
+    local weeks = math.floor(diff / 604800)
+    return weeks == 1 and "1 week ago" or weeks .. " weeks ago"
+  end
+end
+
+---Format reactions for display
+---@param reactions table<string, number>
+---@return string
+local function format_reactions(reactions)
+  if not reactions or vim.tbl_isempty(reactions) then
+    return ""
+  end
+
+  local emoji_map = {
+    THUMBS_UP = "👍",
+    THUMBS_DOWN = "👎",
+    LAUGH = "😄",
+    HOORAY = "🎉",
+    CONFUSED = "😕",
+    HEART = "❤️",
+    ROCKET = "🚀",
+    EYES = "👀",
+  }
+
+  local parts = {}
+  for reaction, count in pairs(reactions) do
+    local emoji = emoji_map[reaction] or reaction
+    table.insert(parts, emoji .. " " .. count)
+  end
+
+  return table.concat(parts, "  ")
+end
+
+---Show thread popup at cursor
+function M.show_thread_at_cursor()
+  local hooks = require("review.hooks")
+  local file, line = hooks.get_cursor_position()
+
+  if not file or not line then
+    vim.notify("Could not determine cursor position", vim.log.levels.WARN, { title = "Review" })
+    return
+  end
+
+  local thread = M.get_at_line(file, line)
+  if not thread then
+    vim.notify("No GitHub thread at this line", vim.log.levels.INFO, { title = "Review" })
+    return
+  end
+
+  M.show_thread(thread)
+end
+
+---Show a thread in a popup
+---@param thread GitHubThread
+function M.show_thread(thread)
+  if thread_popup then
+    thread_popup:unmount()
+    thread_popup = nil
+  end
+
+  local lines = {}
+  local highlights = {}
+
+  -- Header
+  local status = thread.is_resolved and "✓ Resolved" or "◆ Open"
+  if thread.is_outdated then
+    status = status .. " (outdated)"
+  end
+  table.insert(lines, status)
+  table.insert(highlights, { line = #lines, hl = thread.is_resolved and "ReviewGitHubResolved" or "ReviewGitHubThread" })
+  table.insert(lines, string.rep("─", 50))
+
+  -- Comments
+  for i, comment in ipairs(thread.comments) do
+    if i > 1 then
+      table.insert(lines, "")
+      table.insert(lines, string.rep("─", 50))
+    end
+
+    -- Author and time
+    local author_line = string.format("@%s (%s)", comment.author, format_relative_time(comment.created_at))
+    table.insert(lines, author_line)
+    table.insert(highlights, { line = #lines, hl = "ReviewGitHubAuthor" })
+
+    -- Body
+    for _, body_line in ipairs(vim.split(comment.body, "\n")) do
+      table.insert(lines, body_line)
+    end
+
+    -- Reactions
+    local reactions_str = format_reactions(comment.reactions)
+    if reactions_str ~= "" then
+      table.insert(lines, "")
+      table.insert(lines, reactions_str)
+    end
+  end
+
+  -- Footer
+  table.insert(lines, "")
+  table.insert(lines, string.rep("─", 50))
+  table.insert(lines, "[r]eply  [R]esolve  [q]uit")
+  table.insert(highlights, { line = #lines, hl = "Comment" })
+
+  -- Calculate popup size
+  local max_width = 60
+  for _, line in ipairs(lines) do
+    max_width = math.max(max_width, vim.fn.strdisplaywidth(line) + 4)
+  end
+  max_width = math.min(max_width, vim.o.columns - 10)
+  local height = math.min(#lines, vim.o.lines - 10)
+
+  thread_popup = Popup({
+    position = "50%",
+    size = {
+      width = max_width,
+      height = height,
+    },
+    border = {
+      style = "rounded",
+      text = {
+        top = " GitHub Thread ",
+        top_align = "center",
+      },
+    },
+    buf_options = {
+      modifiable = false,
+      buftype = "nofile",
+    },
+    win_options = {
+      wrap = true,
+    },
+  })
+
+  thread_popup:mount()
+
+  local buf = thread_popup.bufnr
+  vim.api.nvim_set_option_value("modifiable", true, { buf = buf })
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+
+  -- Apply highlights
+  local hl_ns = vim.api.nvim_create_namespace("review_thread_popup")
+  for _, hl_info in ipairs(highlights) do
+    vim.api.nvim_buf_add_highlight(buf, hl_ns, hl_info.hl, hl_info.line - 1, 0, -1)
+  end
+
+  -- Keymaps
+  local map_opts = { noremap = true, nowait = true }
+
+  thread_popup:map("n", "q", function()
+    thread_popup:unmount()
+    thread_popup = nil
+  end, map_opts)
+
+  thread_popup:map("n", "<Esc>", function()
+    thread_popup:unmount()
+    thread_popup = nil
+  end, map_opts)
+
+  thread_popup:map("n", "r", function()
+    thread_popup:unmount()
+    thread_popup = nil
+    M.reply_to_thread(thread)
+  end, map_opts)
+
+  thread_popup:map("n", "R", function()
+    thread_popup:unmount()
+    thread_popup = nil
+    M.toggle_resolve(thread)
+  end, map_opts)
+end
+
+---Reply to a thread
+---@param thread GitHubThread
+function M.reply_to_thread(thread)
+  vim.ui.input({ prompt = "Reply: " }, function(input)
+    if not input or input == "" then
+      return
+    end
+
+    local github = require("review.github")
+    local pr = github.get_current_pr()
+    if not pr then
+      vim.notify("No active PR", vim.log.levels.ERROR, { title = "Review" })
+      return
+    end
+
+    -- Use GraphQL to reply
+    local mutation = [[
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: $threadId, body: $body }) {
+    comment {
+      id
+    }
+  }
+}
+]]
+
+    local variables = vim.json.encode({
+      threadId = thread.id,
+      body = input,
+    })
+
+    local cmd = string.format(
+      "gh api graphql -f query=%s -f variables=%s",
+      vim.fn.shellescape(mutation),
+      vim.fn.shellescape(variables)
+    )
+
+    local result = vim.fn.system(cmd)
+    if vim.v.shell_error ~= 0 then
+      vim.notify("Failed to post reply: " .. vim.trim(result), vim.log.levels.ERROR, { title = "Review" })
+      return
+    end
+
+    vim.notify("Reply posted", vim.log.levels.INFO, { title = "Review" })
+
+    -- Refresh threads
+    M.fetch(pr.number)
+    M.render_all()
+  end)
+end
+
+---Toggle thread resolved status
+---@param thread GitHubThread
+function M.toggle_resolve(thread)
+  local github = require("review.github")
+  local pr = github.get_current_pr()
+  if not pr then
+    vim.notify("No active PR", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local mutation
+  if thread.is_resolved then
+    mutation = [[
+mutation($threadId: ID!) {
+  unresolveReviewThread(input: { threadId: $threadId }) {
+    thread { id }
+  }
+}
+]]
+  else
+    mutation = [[
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id }
+  }
+}
+]]
+  end
+
+  local variables = vim.json.encode({ threadId = thread.id })
+  local cmd = string.format(
+    "gh api graphql -f query=%s -f variables=%s",
+    vim.fn.shellescape(mutation),
+    vim.fn.shellescape(variables)
+  )
+
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    vim.notify("Failed to update thread: " .. vim.trim(result), vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local action = thread.is_resolved and "Unresolved" or "Resolved"
+  vim.notify("Thread " .. action:lower(), vim.log.levels.INFO, { title = "Review" })
+
+  -- Refresh threads
+  M.fetch(pr.number)
+  M.render_all()
+end
+
+---Render threads for all codediff buffers
+function M.render_all()
+  local ok, hooks = pcall(require, "review.hooks")
+  if not ok then
+    return
+  end
+
+  local orig_buf, mod_buf = hooks.get_buffers()
+  if orig_buf then
+    M.render_for_buffer(orig_buf)
+  end
+  if mod_buf then
+    M.render_for_buffer(mod_buf)
+  end
+end
+
+---Navigate to next thread
+function M.next_thread()
+  local hooks = require("review.hooks")
+  local file, current_line = hooks.get_cursor_position()
+  if not file then
+    return
+  end
+
+  local threads = M.get_for_file(file)
+  table.sort(threads, function(a, b) return a.line < b.line end)
+
+  for _, thread in ipairs(threads) do
+    if thread.line > current_line then
+      vim.api.nvim_win_set_cursor(0, { thread.line, 0 })
+      return
+    end
+  end
+
+  -- Wrap to first
+  if #threads > 0 then
+    vim.api.nvim_win_set_cursor(0, { threads[1].line, 0 })
+  end
+end
+
+---Navigate to previous thread
+function M.prev_thread()
+  local hooks = require("review.hooks")
+  local file, current_line = hooks.get_cursor_position()
+  if not file then
+    return
+  end
+
+  local threads = M.get_for_file(file)
+  table.sort(threads, function(a, b) return a.line > b.line end)
+
+  for _, thread in ipairs(threads) do
+    if thread.line < current_line then
+      vim.api.nvim_win_set_cursor(0, { thread.line, 0 })
+      return
+    end
+  end
+
+  -- Wrap to last
+  if #threads > 0 then
+    vim.api.nvim_win_set_cursor(0, { threads[1].line, 0 })
+  end
+end
+
+---Start a new thread at cursor position
+function M.start_new_thread()
+  local hooks = require("review.hooks")
+  local file, line = hooks.get_cursor_position()
+
+  if not file or not line then
+    vim.notify("Could not determine cursor position", vim.log.levels.WARN, { title = "Review" })
+    return
+  end
+
+  local github = require("review.github")
+  local pr = github.get_current_pr()
+  if not pr then
+    vim.notify("No active PR review", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local pr_node_id = api.get_pr_node_id(pr.number)
+  if not pr_node_id then
+    vim.notify("Failed to get PR ID", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  vim.ui.input({ prompt = "New thread comment: " }, function(input)
+    if not input or input == "" then
+      return
+    end
+
+    local ok, err = api.add_review_thread(pr_node_id, file, line, input)
+    if not ok then
+      vim.notify("Failed to create thread: " .. (err or "unknown error"), vim.log.levels.ERROR, { title = "Review" })
+      return
+    end
+
+    vim.notify("Thread created", vim.log.levels.INFO, { title = "Review" })
+
+    -- Refresh threads
+    M.fetch(pr.number)
+    M.render_all()
+  end)
+end
+
+---Get the current line content from buffer
+---@return string|nil
+local function get_current_line_content()
+  local current_buf = vim.api.nvim_get_current_buf()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local line_num = cursor[1]
+  local lines = vim.api.nvim_buf_get_lines(current_buf, line_num - 1, line_num, false)
+  return lines[1]
+end
+
+---Start a new suggestion thread at cursor position
+---Uses GitHub's suggestion syntax for one-click apply
+function M.start_suggestion_thread()
+  local hooks = require("review.hooks")
+  local file, line = hooks.get_cursor_position()
+
+  if not file or not line then
+    vim.notify("Could not determine cursor position", vim.log.levels.WARN, { title = "Review" })
+    return
+  end
+
+  local github = require("review.github")
+  local pr = github.get_current_pr()
+  if not pr then
+    vim.notify("No active PR review", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  local pr_node_id = api.get_pr_node_id(pr.number)
+  if not pr_node_id then
+    vim.notify("Failed to get PR ID", vim.log.levels.ERROR, { title = "Review" })
+    return
+  end
+
+  -- Get current line content as default suggestion
+  local current_content = get_current_line_content() or ""
+
+  vim.ui.input({
+    prompt = "Suggested replacement: ",
+    default = current_content,
+  }, function(replacement)
+    if replacement == nil then
+      return
+    end
+
+    -- Build suggestion body with GitHub syntax
+    local body = "```suggestion\n" .. replacement .. "\n```"
+
+    local ok, err = api.add_review_thread(pr_node_id, file, line, body)
+    if not ok then
+      vim.notify("Failed to create suggestion: " .. (err or "unknown error"), vim.log.levels.ERROR, { title = "Review" })
+      return
+    end
+
+    vim.notify("Suggestion created", vim.log.levels.INFO, { title = "Review" })
+
+    -- Refresh threads
+    M.fetch(pr.number)
+    M.render_all()
+  end)
+end
+
+return M

--- a/lua/review/github/threads.lua
+++ b/lua/review/github/threads.lua
@@ -318,6 +318,15 @@ function M.show_hover(bufnr, line)
     table.insert(virt_lines, { { reply_line, "ReviewGitHubVirtText" } })
   end
 
+  -- Hint line
+  local hint_text = "Enter: view • r: reply • R: resolve"
+  local hint_width = vim.fn.strdisplaywidth(hint_text)
+  local hint_padding = content_width - hint_width
+  if hint_padding >= 0 then
+    local hint_line = "│ " .. hint_text .. string.rep(" ", hint_padding) .. " │"
+    table.insert(virt_lines, { { hint_line, "Comment" } })
+  end
+
   -- Bottom border
   local bottom = "╰" .. string.rep("─", content_width + 2) .. "╯"
   table.insert(virt_lines, { { bottom, hl } })
@@ -468,7 +477,7 @@ function M.show_thread(thread)
   -- Footer
   table.insert(lines, "")
   table.insert(lines, string.rep("─", 50))
-  table.insert(lines, "[r]eply  [R]esolve  [e]dit  [d]elete  [+]react  [q]uit")
+  table.insert(lines, "[r]eply  [R]esolve  [e]dit  [d]elete  [+]react  [o]pen  [q]uit")
   table.insert(highlights, { line = #lines, hl = "Comment" })
 
   -- Calculate popup size
@@ -558,6 +567,12 @@ function M.show_thread(thread)
     thread_popup:unmount()
     thread_popup = nil
     M.add_reaction(thread)
+  end, map_opts)
+
+  thread_popup:map("n", "o", function()
+    thread_popup:unmount()
+    thread_popup = nil
+    M.open_thread_in_browser()
   end, map_opts)
 end
 
@@ -1184,7 +1199,7 @@ function M.show_pr_description()
       text = {
         top = " PR Description ",
         top_align = "center",
-        bottom = " q to close ",
+        bottom = " q: close • o: open in browser ",
         bottom_align = "center",
       },
     },
@@ -1216,6 +1231,11 @@ function M.show_pr_description()
   local map_opts = { noremap = true, nowait = true }
   popup:map("n", "q", function() popup:unmount() end, map_opts)
   popup:map("n", "<Esc>", function() popup:unmount() end, map_opts)
+  popup:map("n", "o", function()
+    popup:unmount()
+    vim.fn.system(string.format("open %s", vim.fn.shellescape(pr.url)))
+    vim.notify("Opened PR in browser", vim.log.levels.INFO, { title = "Review" })
+  end, map_opts)
 end
 
 return M

--- a/lua/review/highlights.lua
+++ b/lua/review/highlights.lua
@@ -31,6 +31,14 @@ function M.setup()
   vim.api.nvim_set_hl(0, "ReviewGitHubOutdated", { bg = "#1f1f1f", italic = true, default = true })
   vim.api.nvim_set_hl(0, "ReviewGitHubVirtText", { fg = "#6b7280", italic = true, default = true })
   vim.api.nvim_set_hl(0, "ReviewGitHubAuthor", { fg = "#60a5fa", bold = true, default = true })
+
+  -- PR picker highlights
+  vim.api.nvim_set_hl(0, "ReviewPRIcon", { fg = "#3fb950", default = true }) -- Green PR icon
+  vim.api.nvim_set_hl(0, "ReviewPRDraft", { fg = "#6b7280", italic = true, default = true }) -- Gray for drafts
+  vim.api.nvim_set_hl(0, "ReviewPRNumber", { fg = "#58a6ff", bold = true, default = true }) -- Blue PR number
+  vim.api.nvim_set_hl(0, "ReviewPRBranch", { fg = "#f78166", default = true }) -- Orange branch names
+  vim.api.nvim_set_hl(0, "ReviewPRAuthor", { fg = "#8b949e", default = true }) -- Gray author
+  vim.api.nvim_set_hl(0, "ReviewPRSearch", { fg = "#c9d1d9", italic = true, default = true }) -- Search prompt
 end
 
 return M

--- a/lua/review/highlights.lua
+++ b/lua/review/highlights.lua
@@ -24,6 +24,13 @@ function M.setup()
     text = "●",
     texthl = "ReviewSign",
   })
+
+  -- GitHub thread highlights
+  vim.api.nvim_set_hl(0, "ReviewGitHubThread", { fg = "#7c3aed", bold = true, default = true })
+  vim.api.nvim_set_hl(0, "ReviewGitHubResolved", { fg = "#6b7280", default = true })
+  vim.api.nvim_set_hl(0, "ReviewGitHubOutdated", { bg = "#1f1f1f", italic = true, default = true })
+  vim.api.nvim_set_hl(0, "ReviewGitHubVirtText", { fg = "#6b7280", italic = true, default = true })
+  vim.api.nvim_set_hl(0, "ReviewGitHubAuthor", { fg = "#60a5fa", bold = true, default = true })
 end
 
 return M

--- a/lua/review/init.lua
+++ b/lua/review/init.lua
@@ -111,6 +111,13 @@ function M.open_commits()
   end)
 end
 
+---Open a GitHub PR for review
+---@param number? number PR number (opens picker if nil)
+function M.open_pr(number)
+  local github = require("review.github")
+  github.open(number)
+end
+
 function M.close()
   -- Export comments to clipboard before closing
   local count = store.count()

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -136,6 +136,17 @@ local function set_buffer_keymaps(bufnr)
     require("review.github.submit").show_submit_ui()
   end, vim.tbl_extend("force", opts, { desc = "Submit review to GitHub" }))
 
+  -- Open PR in browser
+  vim.keymap.set("n", "go", function()
+    local github = require("review.github")
+    local pr = github.get_current_pr()
+    if pr then
+      vim.fn.system(string.format("gh pr view %d --web", pr.number))
+    else
+      vim.notify("No active PR review", vim.log.levels.WARN, { title = "Review" })
+    end
+  end, vim.tbl_extend("force", opts, { desc = "Open PR in browser" }))
+
   -- Close and export
   vim.keymap.set("n", "q", function() require("review").close() end, vim.tbl_extend("force", opts, { desc = "Close" }))
 

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -86,6 +86,37 @@ local function set_buffer_keymaps(bufnr)
   vim.keymap.set("n", km.next_comment, function() comments.goto_next() end, vim.tbl_extend("force", opts, { desc = "Next comment" }))
   vim.keymap.set("n", km.prev_comment, function() comments.goto_prev() end, vim.tbl_extend("force", opts, { desc = "Previous comment" }))
 
+  -- GitHub thread keymaps (only active during PR review)
+  vim.keymap.set("n", "gC", function()
+    local threads = require("review.github.threads")
+    threads.show_thread_at_cursor()
+  end, vim.tbl_extend("force", opts, { desc = "Show GitHub thread" }))
+
+  vim.keymap.set("n", "]t", function()
+    local threads = require("review.github.threads")
+    threads.next_thread()
+  end, vim.tbl_extend("force", opts, { desc = "Next GitHub thread" }))
+
+  vim.keymap.set("n", "[t", function()
+    local threads = require("review.github.threads")
+    threads.prev_thread()
+  end, vim.tbl_extend("force", opts, { desc = "Previous GitHub thread" }))
+
+  vim.keymap.set("n", "gn", function()
+    local threads = require("review.github.threads")
+    threads.start_new_thread()
+  end, vim.tbl_extend("force", opts, { desc = "Start new GitHub thread" }))
+
+  vim.keymap.set("n", "gS", function()
+    local threads = require("review.github.threads")
+    threads.start_suggestion_thread()
+  end, vim.tbl_extend("force", opts, { desc = "Start GitHub suggestion" }))
+
+  -- Submit review to GitHub
+  vim.keymap.set("n", "gs", function()
+    require("review.github.submit").show_submit_ui()
+  end, vim.tbl_extend("force", opts, { desc = "Submit review to GitHub" }))
+
   -- Close and export
   vim.keymap.set("n", "q", function() require("review").close() end, vim.tbl_extend("force", opts, { desc = "Close" }))
 

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -112,6 +112,25 @@ local function set_buffer_keymaps(bufnr)
     threads.start_suggestion_thread()
   end, vim.tbl_extend("force", opts, { desc = "Start GitHub suggestion" }))
 
+  -- Visual mode for multi-line comments/suggestions
+  vim.keymap.set("v", "gn", function()
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+    local threads = require("review.github.threads")
+    threads.start_multiline_thread()
+  end, vim.tbl_extend("force", opts, { desc = "Start multi-line GitHub thread" }))
+
+  vim.keymap.set("v", "gS", function()
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+    local threads = require("review.github.threads")
+    threads.start_multiline_suggestion()
+  end, vim.tbl_extend("force", opts, { desc = "Start multi-line GitHub suggestion" }))
+
+  -- PR description
+  vim.keymap.set("n", "gp", function()
+    local threads = require("review.github.threads")
+    threads.show_pr_description()
+  end, vim.tbl_extend("force", opts, { desc = "Show PR description" }))
+
   -- Submit review to GitHub
   vim.keymap.set("n", "gs", function()
     require("review.github.submit").show_submit_ui()

--- a/lua/review/popup.lua
+++ b/lua/review/popup.lua
@@ -5,7 +5,9 @@ local config = require("review.config")
 ---@param initial_type? "note"|"suggestion"|"issue"|"praise"
 ---@param initial_text? string
 ---@param callback fun(comment_type: string|nil, text: string|nil)
-function M.open(initial_type, initial_text, callback)
+---@param current_line? string Current line content for suggestion pre-fill
+---@param allowed_types? string[] Types to show (default: all types)
+function M.open(initial_type, initial_text, callback, current_line, allowed_types)
   local ok_popup, Popup = pcall(require, "nui.popup")
   local ok_layout, Layout = pcall(require, "nui.layout")
 
@@ -27,7 +29,7 @@ function M.open(initial_type, initial_text, callback)
   end
 
   local cfg = config.get()
-  local type_keys = { "note", "suggestion", "issue", "praise" }
+  local type_keys = allowed_types or { "note", "suggestion", "issue", "praise" }
   local current_type_idx = 1
 
   -- Find initial type index
@@ -86,6 +88,14 @@ function M.open(initial_type, initial_text, callback)
     }, { dir = "col" })
   )
 
+  local function get_text()
+    local lines = vim.api.nvim_buf_get_lines(text_popup.bufnr, 0, -1, false)
+    local text = table.concat(lines, "\n")
+    -- Trim trailing whitespace/newlines
+    text = text:gsub("%s+$", "")
+    return text
+  end
+
   local function render_types()
     local parts = {}
     for i, key in ipairs(type_keys) do
@@ -107,14 +117,18 @@ function M.open(initial_type, initial_text, callback)
     current_type_idx = current_type_idx % #type_keys + 1
     vim.api.nvim_set_option_value("modifiable", true, { buf = type_popup.bufnr })
     render_types()
-  end
 
-  local function get_text()
-    local lines = vim.api.nvim_buf_get_lines(text_popup.bufnr, 0, -1, false)
-    local text = table.concat(lines, "\n")
-    -- Trim trailing whitespace/newlines
-    text = text:gsub("%s+$", "")
-    return text
+    -- If switching to suggestion and text is empty, pre-fill with suggestion syntax
+    if type_keys[current_type_idx] == "suggestion" and current_line then
+      local current_text = get_text()
+      if current_text == "" then
+        local suggestion_text = "```suggestion\n" .. current_line .. "\n```"
+        local lines = vim.split(suggestion_text, "\n")
+        vim.api.nvim_buf_set_lines(text_popup.bufnr, 0, -1, false, lines)
+        -- Position cursor inside the suggestion block
+        vim.api.nvim_win_set_cursor(text_popup.winid, { 2, 0 })
+      end
+    end
   end
 
   local function submit()

--- a/lua/review/popup.lua
+++ b/lua/review/popup.lua
@@ -61,8 +61,10 @@ function M.open(initial_type, initial_text, callback, current_line, allowed_type
     border = {
       style = "rounded",
       text = {
-        top = " Comment (C-s: submit) ",
+        top = " Comment ",
         top_align = "center",
+        bottom = " C-s: submit • Esc: cancel ",
+        bottom_align = "center",
       },
     },
     win_options = {

--- a/plugin/review.lua
+++ b/plugin/review.lua
@@ -6,7 +6,21 @@ vim.g.loaded_review = true
 local subcommands = {
   open = { fn = function() require("review").open() end, desc = "Open codediff with review" },
   commits = { fn = function() require("review").open_commits() end, desc = "Select commits to review" },
-  PR = { fn = function(args) require("review").open_pr(args[2] and tonumber(args[2])) end, desc = "Review a GitHub PR" },
+  PR = {
+    fn = function(args)
+      if args[2] then
+        local pr_number = tonumber(args[2])
+        if not pr_number then
+          vim.notify("Invalid PR number: " .. args[2], vim.log.levels.ERROR, { title = "Review" })
+          return
+        end
+        require("review").open_pr(pr_number)
+      else
+        require("review").open_pr()
+      end
+    end,
+    desc = "Review a GitHub PR",
+  },
   submit = { fn = function() require("review.github.submit").show_submit_ui() end, desc = "Submit review to GitHub" },
   close = { fn = function() require("review").close() end, desc = "Close and export to clipboard" },
   export = { fn = function() require("review").export() end, desc = "Export comments to clipboard" },

--- a/plugin/review.lua
+++ b/plugin/review.lua
@@ -6,6 +6,8 @@ vim.g.loaded_review = true
 local subcommands = {
   open = { fn = function() require("review").open() end, desc = "Open codediff with review" },
   commits = { fn = function() require("review").open_commits() end, desc = "Select commits to review" },
+  PR = { fn = function(args) require("review").open_pr(args[2] and tonumber(args[2])) end, desc = "Review a GitHub PR" },
+  submit = { fn = function() require("review.github.submit").show_submit_ui() end, desc = "Submit review to GitHub" },
   close = { fn = function() require("review").close() end, desc = "Close and export to clipboard" },
   export = { fn = function() require("review").export() end, desc = "Export comments to clipboard" },
   preview = { fn = function() require("review").preview() end, desc = "Preview exported markdown" },
@@ -28,7 +30,7 @@ vim.api.nvim_create_user_command("Review", function(opts)
 
   local subcmd = subcommands[cmd]
   if subcmd then
-    subcmd.fn()
+    subcmd.fn(args)
   else
     vim.notify("Unknown subcommand: " .. cmd .. "\nAvailable: " .. table.concat(subcommand_names, ", "), vim.log.levels.ERROR, { title = "Review" })
   end

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
         {"type": "ci", "section": "Continuous Integration", "hidden": false},
         {"type": "perf", "section": "Performance Improvements", "hidden": false},
         {"type": "style", "section": "Styles", "hidden": true},
-        {"type": "revert", "section": "Reverts", "hidden": false}
+        {"type": "revert", "section": "Reverts", "hidden": false},
+        {"type": "", "section": "Other Changes", "hidden": false}
       ]
     }
   },

--- a/tests/popup_spec.lua
+++ b/tests/popup_spec.lua
@@ -1,0 +1,149 @@
+local config = require("review.config")
+
+describe("review.popup", function()
+  before_each(function()
+    config.setup()
+  end)
+
+  describe("allowed_types parameter", function()
+    it("module loads without error", function()
+      local popup = require("review.popup")
+      assert.is_not_nil(popup)
+      assert.is_not_nil(popup.open)
+    end)
+
+    it("open function signature accepts 5 parameters", function()
+      local popup = require("review.popup")
+
+      -- Verify the function exists and can be inspected
+      local info = debug.getinfo(popup.open, "u")
+      -- The function should accept at least 5 parameters (initial_type, initial_text, callback, current_line, allowed_types)
+      -- Note: Lua doesn't enforce parameter counts, but we verify the function exists
+      assert.is_function(popup.open)
+
+      -- Verify module structure
+      assert.is_table(popup)
+    end)
+  end)
+
+  describe("type filtering logic", function()
+    -- Test the type_keys logic directly
+    it("filters to only allowed types when specified", function()
+      local all_types = { "note", "suggestion", "issue", "praise" }
+      local allowed_types = { "note", "suggestion" }
+
+      local type_keys = allowed_types or all_types
+
+      assert.equals(2, #type_keys)
+      assert.equals("note", type_keys[1])
+      assert.equals("suggestion", type_keys[2])
+    end)
+
+    it("uses all types when allowed_types is nil", function()
+      local all_types = { "note", "suggestion", "issue", "praise" }
+      local allowed_types = nil
+
+      local type_keys = allowed_types or all_types
+
+      assert.equals(4, #type_keys)
+    end)
+
+    it("initial_type falls back to first allowed type if not in list", function()
+      local allowed_types = { "note", "suggestion" }
+      local initial_type = "issue" -- not in allowed list
+
+      local current_type_idx = 1
+      if initial_type then
+        for i, key in ipairs(allowed_types) do
+          if key == initial_type then
+            current_type_idx = i
+            break
+          end
+        end
+      end
+
+      -- issue is not in allowed_types, so index stays at 1 (note)
+      assert.equals(1, current_type_idx)
+      assert.equals("note", allowed_types[current_type_idx])
+    end)
+
+    it("initial_type selects correct index when in allowed list", function()
+      local allowed_types = { "note", "suggestion" }
+      local initial_type = "suggestion"
+
+      local current_type_idx = 1
+      if initial_type then
+        for i, key in ipairs(allowed_types) do
+          if key == initial_type then
+            current_type_idx = i
+            break
+          end
+        end
+      end
+
+      assert.equals(2, current_type_idx)
+      assert.equals("suggestion", allowed_types[current_type_idx])
+    end)
+  end)
+
+  describe("suggestion pre-fill", function()
+    it("generates correct suggestion syntax", function()
+      local current_line = "  local x = 1"
+      local suggestion_text = "```suggestion\n" .. current_line .. "\n```"
+
+      assert.equals("```suggestion\n  local x = 1\n```", suggestion_text)
+    end)
+
+    it("splits suggestion into lines correctly", function()
+      local current_line = "  local x = 1"
+      local suggestion_text = "```suggestion\n" .. current_line .. "\n```"
+      local lines = vim.split(suggestion_text, "\n")
+
+      assert.equals(3, #lines)
+      assert.equals("```suggestion", lines[1])
+      assert.equals("  local x = 1", lines[2])
+      assert.equals("```", lines[3])
+    end)
+  end)
+
+  describe("PR mode detection", function()
+    it("is_pr_mode returns false when no PR context", function()
+      -- Ensure github module returns nil for current PR
+      package.loaded["review.github"] = {
+        get_current_pr = function() return nil end
+      }
+
+      local function is_pr_mode()
+        local ok, github = pcall(require, "review.github")
+        if ok and github.get_current_pr then
+          return github.get_current_pr() ~= nil
+        end
+        return false
+      end
+
+      assert.is_false(is_pr_mode())
+
+      package.loaded["review.github"] = nil
+    end)
+
+    it("is_pr_mode returns true when PR context exists", function()
+      package.loaded["review.github"] = {
+        get_current_pr = function()
+          return { number = 123, title = "Test PR" }
+        end
+      }
+
+      local function is_pr_mode()
+        local ok, github = pcall(require, "review.github")
+        if ok and github.get_current_pr then
+          return github.get_current_pr() ~= nil
+        end
+        return false
+      end
+
+      assert.is_true(is_pr_mode())
+
+      package.loaded["review.github"] = nil
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

Adds native GitHub PR review support using the `gh` CLI:

- PR picker with search filtering (`:Review PR`)
- View existing review threads with full conversation history
- Start new threads (`gn`) or code suggestions (`gS`) 
- Multi-line comments/suggestions via visual selection
- Reply, resolve/unresolve, edit, delete comments
- Add reactions to comments
- Open PR in browser (`go`)
- Submit reviews with APPROVE/COMMENT/REQUEST_CHANGES (`gs`)
- Two workflows: quick ad-hoc comments (`gn`/`gS`) or batch review (`i` + `gs`)

Also includes comparison with octo.nvim in the README explaining when to use each.