### PR TITLE
feat: write to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Inspired by [tuicr](https://github.com/agavra/tuicr).
 - Comments displayed as signs, line highlights, and virtual text
 - Comments persist per branch (stored in `~/.local/share/nvim/review/`)
 - Auto-export comments to clipboard when closing
+- Export comments to a project review file (default: `CODE_REVIEW.md`)
+- Import existing review file on open to restore comments
 - Export format optimized for AI conversations
 - Send comments directly to [sidekick.nvim](https://github.com/folke/sidekick.nvim) for AI chat
 - Commit picker modal to select specific commits to review
@@ -51,6 +53,8 @@ Using lazy.nvim:
 :Review close        " Close and export comments to clipboard
 :Review export       " Export comments to clipboard
 :Review preview      " Preview exported markdown in split
+:Review write        " Write review markdown file
+:Review write_close  " Write review file, copy to clipboard, and close
 :Review sidekick     " Send comments to sidekick.nvim
 :Review list         " List all comments
 :Review clear        " Clear all comments
@@ -76,6 +80,8 @@ Using lazy.nvim:
 | `S` | Send comments to sidekick.nvim |
 | `<C-r>` | Clear all comments |
 | `q` | Close and export comments to clipboard |
+| `w` | Write review file, copy to clipboard, and close |
+| `W` | Write review file |
 
 **Edit mode** (when `readonly = false`):
 | Key | Action |
@@ -115,6 +121,12 @@ require("review").setup({
   export = {
     context_lines = 3,
     include_file_stats = true,
+    file = {
+      enabled = true,
+      filename = "CODE_REVIEW.md",
+      dir = ".",
+      import_on_open = true,
+    },
   },
   codediff = {
     readonly = true,
@@ -124,16 +136,16 @@ require("review").setup({
 
 ## Export Format
 
-Comments are exported as Markdown optimized for AI consumption:
+Comments are exported as Markdown optimized for AI consumption. When writing to a file, each comment line includes a short inline marker (e.g. `<!--r:id=...-->`) so the plugin can restore comments on the next session without adding a large metadata block.
 
 ```markdown
 I reviewed your code and have the following comments. Please address them.
 
 Comment types: ISSUE (problems to fix), SUGGESTION (improvements), NOTE (observations), PRAISE (positive feedback)
 
-1. **[ISSUE]** `src/components/Button.tsx:23` - Wrapping onClick creates a new function every render
-2. **[SUGGESTION]** `src/utils/api.ts:45` - Consider using useMemo here
-3. **[PRAISE]** `src/hooks/useAuth.ts:12` - Clean implementation of the auth flow
+1. **[ISSUE]** `src/components/Button.tsx:23` - Wrapping onClick creates a new function every render <!--r:id=comment_1700000000_1-->
+2. **[SUGGESTION]** `src/utils/api.ts:45` - Consider using useMemo here <!--r:id=comment_1700000000_2-->
+3. **[PRAISE]** `src/hooks/useAuth.ts:12` - Clean implementation of the auth flow <!--r:id=comment_1700000000_3-->
 ```
 
 ## Running Tests

--- a/lua/review/config.lua
+++ b/lua/review/config.lua
@@ -23,9 +23,16 @@ local M = {}
 ---@field next_comment string
 ---@field prev_comment string
 
+---@class ReviewExportFileConfig
+---@field enabled boolean
+---@field filename string
+---@field dir string
+---@field import_on_open boolean
+
 ---@class ReviewExportConfig
 ---@field context_lines number
 ---@field include_file_stats boolean
+---@field file ReviewExportFileConfig
 
 ---@class ReviewCodediffConfig
 ---@field readonly boolean
@@ -51,6 +58,12 @@ M.defaults = {
   export = {
     context_lines = 3,
     include_file_stats = true,
+    file = {
+      enabled = true,
+      filename = "CODE_REVIEW.md",
+      dir = ".",
+      import_on_open = true,
+    },
   },
   codediff = {
     readonly = true,

--- a/lua/review/file.lua
+++ b/lua/review/file.lua
@@ -3,7 +3,7 @@ local M = {}
 local config = require("review.config")
 local store = require("review.store")
 local export = require("review.export")
-local hooks = require("review.hooks")
+local review = require("review")
 
 local id_marker_prefix = "<!--r:id="
 local id_marker_suffix = "-->"
@@ -269,15 +269,10 @@ function M.write_from_store(opts)
   end
 
   if opts and opts.close then
-    M.close_tab_only()
+    review.close_tab_only()
   end
 
   return true
-end
-
-function M.close_tab_only()
-  vim.cmd("tabclose")
-  hooks.on_session_closed()
 end
 
 return M

--- a/lua/review/file.lua
+++ b/lua/review/file.lua
@@ -3,7 +3,6 @@ local M = {}
 local config = require("review.config")
 local store = require("review.store")
 local export = require("review.export")
-local review = require("review")
 
 
 ---@return string|nil
@@ -213,7 +212,8 @@ function M.write_from_store(opts)
   end
 
   if opts and opts.close then
-    review.close_tab_only()
+    vim.cmd("tabclose")
+    require("review.hooks").on_session_closed()
   end
 
   return true

--- a/lua/review/file.lua
+++ b/lua/review/file.lua
@@ -1,0 +1,283 @@
+local M = {}
+
+local config = require("review.config")
+local store = require("review.store")
+local export = require("review.export")
+local hooks = require("review.hooks")
+
+local id_marker_prefix = "<!--r:id="
+local id_marker_suffix = "-->"
+
+---@return string|nil
+local function get_git_root()
+  local handle = io.popen("git rev-parse --show-toplevel 2>/dev/null")
+  if handle then
+    local result = handle:read("*a")
+    handle:close()
+    if result and result ~= "" then
+      return result:gsub("%s+$", "")
+    end
+  end
+  return nil
+end
+
+---@return string|nil
+local function get_export_path()
+  local cfg = config.get().export.file
+  if not cfg or not cfg.enabled then
+    return nil
+  end
+
+  local git_root = get_git_root()
+  if not git_root then
+    return nil
+  end
+
+  local dir = cfg.dir or "."
+  if not dir or dir == "" then
+    dir = "."
+  end
+
+  local base
+  if dir:sub(1, 1) == "/" then
+    base = dir
+  else
+    base = git_root .. "/" .. dir
+  end
+
+  local filename = cfg.filename or "CODE_REVIEW.md"
+  return base .. "/" .. filename
+end
+
+---@param path string
+---@return boolean
+local function ensure_dir(path)
+  local dir = vim.fn.fnamemodify(path, ":h")
+  if dir == "" then
+    return false
+  end
+  local ok, err = pcall(vim.fn.mkdir, dir, "p")
+  if not ok then
+    vim.notify("Failed to create directory: " .. dir .. " (" .. tostring(err) .. ")", vim.log.levels.ERROR, { title = "Review" })
+    return false
+  end
+  return true
+end
+
+---@param path string
+---@return string
+local function normalize_path(path)
+  if not path then
+    return path
+  end
+  path = path:gsub("^%./", "")
+  path = path:gsub("/+$", "")
+  return path
+end
+
+---@param line string
+---@return string|nil
+---@return string
+local function extract_id(line)
+  local id = nil
+  local start_pos = line:find(id_marker_prefix, 1, true)
+  if not start_pos then
+    return nil, line
+  end
+
+  local end_pos = line:find(id_marker_suffix, start_pos + #id_marker_prefix, true)
+  if not end_pos then
+    return nil, line
+  end
+
+  local id_start = start_pos + #id_marker_prefix
+  local id_end = end_pos - 1
+  if id_start <= id_end then
+    id = line:sub(id_start, id_end)
+  end
+
+  local cleaned = line:sub(1, start_pos - 1):gsub("%s+$", "")
+  return id, cleaned
+end
+
+---@param type_str string
+---@return string|nil
+local function normalize_type(type_str)
+  local t = type_str:lower()
+  if t == "note" or t == "suggestion" or t == "issue" or t == "praise" then
+    return t
+  end
+  return nil
+end
+
+---@param path_with_line string
+---@return string|nil
+---@return number|nil
+local function split_path_line(path_with_line)
+  local path, line_str = path_with_line:match("^(.*):(%d+)$")
+  if not path or not line_str then
+    return nil, nil
+  end
+  local line_num = tonumber(line_str)
+  if not line_num then
+    return nil, nil
+  end
+  return path, line_num
+end
+
+---@param line string
+---@return table|nil
+local function parse_comment_line(line)
+  local id, cleaned = extract_id(line)
+
+  local type_str = cleaned:match("%*%*%[([^%]]+)%]%*%*")
+  if not type_str then
+    return nil
+  end
+
+  local normalized_type = normalize_type(type_str)
+  if not normalized_type then
+    return nil
+  end
+
+  local loc = cleaned:match("`([^`]+)`")
+  if not loc then
+    return nil
+  end
+
+  local file, line_num = split_path_line(loc)
+  if not file or not line_num then
+    return nil
+  end
+
+  local text = cleaned:match(" %- (.+)$")
+  if not text or text == "" then
+    return nil
+  end
+
+  local comment_id = id or store.generate_id()
+
+  return {
+    id = comment_id,
+    file = normalize_path(file),
+    line = line_num,
+    type = normalized_type,
+    text = text,
+    created_at = os.time(),
+  }
+end
+
+---@param comments table<string, table>
+---@param comment table
+local function add_comment(comments, comment)
+  if not comments[comment.file] then
+    comments[comment.file] = {}
+  end
+  table.insert(comments[comment.file], comment)
+end
+
+---@param path string
+---@return table<string, table>
+local function parse_file(path)
+  local file = io.open(path, "r")
+  if not file then
+    return {}
+  end
+
+  local comments = {}
+  for line in file:lines() do
+    local comment = parse_comment_line(line)
+    if comment then
+      add_comment(comments, comment)
+    end
+  end
+
+  file:close()
+  return comments
+end
+
+---@return boolean
+function M.load_into_store()
+  local path = get_export_path()
+  if not path then
+    return false
+  end
+
+  local stat = vim.loop.fs_stat(path)
+  if not stat then
+    return false
+  end
+
+  local comments = parse_file(path)
+  store.replace_all(comments)
+  return true
+end
+
+---@param include_ids boolean
+---@return string
+local function generate_markdown(include_ids)
+  local all_comments = store.get_all()
+
+  if #all_comments == 0 then
+    return "No comments yet."
+  end
+
+  local lines = {}
+  table.insert(lines, "I reviewed your code and have the following comments. Please address them.")
+  table.insert(lines, "")
+  table.insert(lines, "Comment types: ISSUE (problems to fix), SUGGESTION (improvements), NOTE (observations), PRAISE (positive feedback)")
+  table.insert(lines, "")
+
+  for i, comment in ipairs(all_comments) do
+    local type_name = string.upper(comment.type)
+    local line = string.format("%d. **[%s]** `%s:%d` - %s", i, type_name, comment.file, comment.line, comment.text)
+    if include_ids then
+      line = line .. " " .. id_marker_prefix .. comment.id .. id_marker_suffix
+    end
+    table.insert(lines, line)
+  end
+
+  return table.concat(lines, "\n")
+end
+
+---@param opts? { copy: boolean, close: boolean }
+---@return boolean
+function M.write_from_store(opts)
+  local path = get_export_path()
+  if not path then
+    return false
+  end
+
+  if not ensure_dir(path) then
+    return false
+  end
+
+  local markdown = generate_markdown(true)
+  local file = io.open(path, "w")
+  if not file then
+    return false
+  end
+
+  file:write(markdown)
+  file:close()
+
+  local count = store.count()
+  vim.notify(string.format("Wrote %d comment(s) to %s", count, vim.fn.fnamemodify(path, ":.")), vim.log.levels.INFO, { title = "Review" })
+
+  if opts and opts.copy then
+    export.to_clipboard()
+  end
+
+  if opts and opts.close then
+    M.close_tab_only()
+  end
+
+  return true
+end
+
+function M.close_tab_only()
+  vim.cmd("tabclose")
+  hooks.on_session_closed()
+end
+
+return M

--- a/lua/review/init.lua
+++ b/lua/review/init.lua
@@ -120,7 +120,7 @@ function M.open_commits()
   end)
 end
 
-local function close_tab_only()
+function M.close_tab_only()
   vim.cmd("tabclose")
   hooks.on_session_closed()
 end
@@ -136,7 +136,7 @@ function M.close()
   end
 
   -- Close the tab
-  close_tab_only()
+  M.close_tab_only()
 end
 
 function M.export()

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -89,8 +89,8 @@ local function set_buffer_keymaps(bufnr)
   -- Close and export
   vim.keymap.set("n", "q", function() require("review").close() end, vim.tbl_extend("force", opts, { desc = "Close" }))
 
-  vim.keymap.set("n", "w", function() require("review").write_close() end, vim.tbl_extend("force", opts, { desc = "Write review file and close" }))
-  vim.keymap.set("n", "W", function() require("review").write() end, vim.tbl_extend("force", opts, { desc = "Write review file" }))
+  vim.keymap.set("n", "x", function() require("review").write_close() end, vim.tbl_extend("force", opts, { desc = "Write review file and close" }))
+  vim.keymap.set("n", "X", function() require("review").write() end, vim.tbl_extend("force", opts, { desc = "Write review file" }))
 
   -- Toggle readonly mode
   vim.keymap.set("n", "R", function() require("review").toggle_readonly() end, vim.tbl_extend("force", opts, { desc = "Toggle readonly mode" }))

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -89,6 +89,9 @@ local function set_buffer_keymaps(bufnr)
   -- Close and export
   vim.keymap.set("n", "q", function() require("review").close() end, vim.tbl_extend("force", opts, { desc = "Close" }))
 
+  vim.keymap.set("n", "w", function() require("review").write_close() end, vim.tbl_extend("force", opts, { desc = "Write review file and close" }))
+  vim.keymap.set("n", "W", function() require("review").write() end, vim.tbl_extend("force", opts, { desc = "Write review file" }))
+
   -- Toggle readonly mode
   vim.keymap.set("n", "R", function() require("review").toggle_readonly() end, vim.tbl_extend("force", opts, { desc = "Toggle readonly mode" }))
 

--- a/lua/review/store.lua
+++ b/lua/review/store.lua
@@ -22,6 +22,10 @@ local function generate_id()
   return string.format("comment_%d_%d", os.time(), id_counter)
 end
 
+function M.generate_id()
+  return generate_id()
+end
+
 local function persist()
   storage.save(M.comments)
 end
@@ -166,6 +170,21 @@ function M.count()
     count = count + #comments
   end
   return count
+end
+
+function M.replace_all(comments)
+  M.comments = comments or {}
+  id_counter = 0
+  for _, comment_list in pairs(M.comments) do
+    for _, comment in ipairs(comment_list) do
+      local num = tonumber(comment.id and comment.id:match("comment_%d+_(%d+)"))
+      if num and num > id_counter then
+        id_counter = num
+      end
+    end
+  end
+  loaded = true
+  storage.save(M.comments)
 end
 
 function M.clear()

--- a/plugin/review.lua
+++ b/plugin/review.lua
@@ -9,6 +9,8 @@ local subcommands = {
   close = { fn = function() require("review").close() end, desc = "Close and export to clipboard" },
   export = { fn = function() require("review").export() end, desc = "Export comments to clipboard" },
   preview = { fn = function() require("review").preview() end, desc = "Preview exported markdown" },
+  write = { fn = function() require("review").write() end, desc = "Write review file" },
+  write_close = { fn = function() require("review").write_close() end, desc = "Write review file and close" },
   sidekick = { fn = function() require("review.export").to_sidekick() end, desc = "Send comments to sidekick.nvim" },
   clear = { fn = function() require("review").clear() end, desc = "Clear all comments" },
   list = { fn = function() require("review.comments").list() end, desc = "List all comments" },

--- a/tests/file_spec.lua
+++ b/tests/file_spec.lua
@@ -43,16 +43,11 @@ describe("review.file", function()
     end
   end)
 
-  it("writes markdown with inline ids and reloads", function()
-    local comment = store.add("src/main.lua", 12, "issue", "Fix this bug")
+  it("writes markdown and reloads", function()
+    store.add("src/main.lua", 12, "issue", "Fix this bug")
 
     local ok = file.write_from_store({ copy = false, close = false })
     assert.is_true(ok)
-
-    local content = read_file(file_path)
-    assert.is_truthy(content)
-    local marker = "<!--r:id=" .. comment.id .. "-->"
-    assert.is_truthy(content:find(marker, 1, true))
 
     store.clear()
     local loaded = file.load_into_store()
@@ -60,7 +55,7 @@ describe("review.file", function()
 
     local all = store.get_all()
     assert.equals(1, #all)
-    assert.equals(comment.id, all[1].id)
+    assert.matches("^comment_%d+_%d+$", all[1].id)
     assert.equals("src/main.lua", all[1].file)
     assert.equals(12, all[1].line)
     assert.equals("issue", all[1].type)

--- a/tests/file_spec.lua
+++ b/tests/file_spec.lua
@@ -1,0 +1,95 @@
+local config = require("review.config")
+local store = require("review.store")
+local file = require("review.file")
+
+local function read_file(path)
+  local handle = io.open(path, "r")
+  if not handle then
+    return nil
+  end
+  local content = handle:read("*a")
+  handle:close()
+  return content
+end
+
+describe("review.file", function()
+  local original_config
+  local temp_dir
+  local file_path
+
+  before_each(function()
+    original_config = vim.deepcopy(config.get())
+    temp_dir = vim.fn.tempname()
+    vim.fn.mkdir(temp_dir, "p")
+    config.setup({
+      export = {
+        file = {
+          enabled = true,
+          filename = "CODE_REVIEW.md",
+          dir = temp_dir,
+          import_on_open = true,
+        },
+      },
+    })
+    file_path = temp_dir .. "/CODE_REVIEW.md"
+    store.clear()
+  end)
+
+  after_each(function()
+    config.setup(original_config)
+    store.clear()
+    if temp_dir then
+      vim.fn.delete(temp_dir, "rf")
+    end
+  end)
+
+  it("writes markdown with inline ids and reloads", function()
+    local comment = store.add("src/main.lua", 12, "issue", "Fix this bug")
+
+    local ok = file.write_from_store({ copy = false, close = false })
+    assert.is_true(ok)
+
+    local content = read_file(file_path)
+    assert.is_truthy(content)
+    local marker = "<!--r:id=" .. comment.id .. "-->"
+    assert.is_truthy(content:find(marker, 1, true))
+
+    store.clear()
+    local loaded = file.load_into_store()
+    assert.is_true(loaded)
+
+    local all = store.get_all()
+    assert.equals(1, #all)
+    assert.equals(comment.id, all[1].id)
+    assert.equals("src/main.lua", all[1].file)
+    assert.equals(12, all[1].line)
+    assert.equals("issue", all[1].type)
+    assert.equals("Fix this bug", all[1].text)
+  end)
+
+  it("generates ids when markers are missing", function()
+    local markdown = table.concat({
+      "I reviewed your code and have the following comments. Please address them.",
+      "",
+      "Comment types: ISSUE (problems to fix), SUGGESTION (improvements), NOTE (observations), PRAISE (positive feedback)",
+      "",
+      "1. **[NOTE]** `src/app.lua:4` - Note without marker",
+    }, "\n")
+
+    local handle = io.open(file_path, "w")
+    assert.is_truthy(handle)
+    handle:write(markdown)
+    handle:close()
+
+    local loaded = file.load_into_store()
+    assert.is_true(loaded)
+
+    local all = store.get_all()
+    assert.equals(1, #all)
+    assert.matches("^comment_%d+_%d+$", all[1].id)
+    assert.equals("note", all[1].type)
+    assert.equals("src/app.lua", all[1].file)
+    assert.equals(4, all[1].line)
+    assert.equals("Note without marker", all[1].text)
+  end)
+end)


### PR DESCRIPTION
I'm running my agentic tasks often in an isolated vm where there is not always a clipboard available. I added a write to file and read from that file (if it exists) functionality. This allows manual edits of that `CODE_REVIEW.md` file afterwards while ensuring consistent storage.

Let me know what you think.

Cheers, Paul