### PR TITLE
feat: improve edit mode and make all keymaps configurable

### DIFF
--- a/lua/review/config.lua
+++ b/lua/review/config.lua
@@ -14,14 +14,25 @@ local M = {}
 ---@field line_hl string
 
 ---@class ReviewKeymaps
----@field add_note string
----@field add_suggestion string
----@field add_issue string
----@field add_praise string
----@field delete_comment string
----@field edit_comment string
----@field next_comment string
----@field prev_comment string
+---@field add_note string|false
+---@field add_suggestion string|false
+---@field add_issue string|false
+---@field add_praise string|false
+---@field delete_comment string|false
+---@field edit_comment string|false
+---@field next_comment string|false
+---@field prev_comment string|false
+---@field list_comments string|false
+---@field export_clipboard string|false
+---@field send_sidekick string|false
+---@field clear_comments string|false
+---@field close string|false
+---@field toggle_readonly string|false
+---@field next_file string|false
+---@field prev_file string|false
+---@field readonly_add string|false
+---@field readonly_delete string|false
+---@field readonly_edit string|false
 
 ---@class ReviewExportConfig
 ---@field context_lines number
@@ -39,14 +50,29 @@ M.defaults = {
     praise = { key = "p", name = "Praise", icon = "✨", hl = "ReviewPraise", line_hl = "ReviewPraiseLine" },
   },
   keymaps = {
+    -- Edit mode (leader-based)
     add_note = "<leader>cn",
     add_suggestion = "<leader>cs",
     add_issue = "<leader>ci",
     add_praise = "<leader>cp",
     delete_comment = "<leader>cd",
     edit_comment = "<leader>ce",
+    -- Navigation
     next_comment = "]n",
     prev_comment = "[n",
+    next_file = "<Tab>",
+    prev_file = "<S-Tab>",
+    -- Common actions
+    list_comments = "c",
+    export_clipboard = "C",
+    send_sidekick = "S",
+    clear_comments = "<C-r>",
+    close = "q",
+    toggle_readonly = "R",
+    -- Readonly mode (simple keys)
+    readonly_add = "i",
+    readonly_delete = "d",
+    readonly_edit = "e",
   },
   export = {
     context_lines = 3,


### PR DESCRIPTION
## Summary

This PR addresses the issue where edit mode was unusable because common keys like `c`, `d`, `e`, `<C-r>` were hijacked even when not actively reviewing.

### Changes

**Edit mode now only sets minimal keymaps:**
- `<Tab>` / `<S-Tab>` - file navigation
- `q` - close
- `R` - toggle to readonly mode

This allows normal editing with `c`, `i`, `d`, `e`, etc.

**Readonly mode has full review keymaps** - all comment actions, navigation, and export functions.

**Toggle (`R`) now properly cleans up old keymaps** before setting new ones.

**All keymaps can be disabled** by setting them to `false`:

```lua
opts = {
  keymaps = {
    list_comments = false,
    clear_comments = false,
  },
}
```

### New configurable keymaps

- `list_comments`, `export_clipboard`, `send_sidekick`, `clear_comments`
- `close`, `toggle_readonly`, `next_file`, `prev_file`
- `readonly_add`, `readonly_delete`, `readonly_edit`

### Related

This is an alternative to #13 that goes further by:
1. Supporting `false` to disable keymaps entirely
2. Restructuring edit mode to not hijack common editing keys by default
3. Properly cleaning up keymaps when toggling modes