### PR TITLE
fix(popup): exit insert mode after submit, add configurable keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ All keymaps can be set to `false` to disable them.
 | `readonly_add` | `i` | Add comment (readonly mode) |
 | `readonly_delete` | `d` | Delete comment (readonly mode) |
 | `readonly_edit` | `e` | Edit comment (readonly mode) |
+| `popup_submit` | `<C-s>` | Submit comment (popup, insert & normal) |
+| `popup_cancel` | `q` | Cancel comment (popup, normal mode) |
+| `popup_cycle_type` | `<Tab>` | Cycle comment type (popup) |
 
 ```lua
 require("review").setup({

--- a/lua/review/config.lua
+++ b/lua/review/config.lua
@@ -34,6 +34,9 @@ local M = {}
 ---@field readonly_add string|false
 ---@field readonly_delete string|false
 ---@field readonly_edit string|false
+---@field popup_submit string|false
+---@field popup_cancel string|false
+---@field popup_cycle_type string|false
 
 ---@class ReviewExportConfig
 ---@field context_lines number
@@ -75,6 +78,10 @@ M.defaults = {
     readonly_add = "i",
     readonly_delete = "d",
     readonly_edit = "e",
+    -- Popup keymaps
+    popup_submit = "<C-s>",
+    popup_cancel = "q",
+    popup_cycle_type = "<Tab>",
   },
   export = {
     context_lines = 3,

--- a/lua/review/popup.lua
+++ b/lua/review/popup.lua
@@ -23,6 +23,7 @@ function M.open(initial_type, initial_text, callback)
       if prev_win and vim.api.nvim_win_is_valid(prev_win) then
         vim.api.nvim_set_current_win(prev_win)
       end
+      vim.cmd("stopinsert")
     end, 10)
   end
 
@@ -147,16 +148,24 @@ function M.open(initial_type, initial_text, callback)
   vim.api.nvim_set_current_win(text_popup.winid)
   vim.cmd("startinsert")
 
-  -- TAB to cycle types
-  vim.keymap.set({ "i", "n" }, "<Tab>", cycle_type, { buffer = text_popup.bufnr, noremap = true })
+  local km = cfg.keymaps
 
-  -- C-s to submit from insert mode (Enter inserts newlines normally)
-  vim.keymap.set("i", "<C-s>", submit, { buffer = text_popup.bufnr, noremap = true })
+  -- Cycle types
+  if km.popup_cycle_type then
+    vim.keymap.set({ "i", "n" }, km.popup_cycle_type, cycle_type, { buffer = text_popup.bufnr, noremap = true })
+  end
 
-  -- Normal mode mappings
+  -- Submit (both modes)
+  if km.popup_submit then
+    vim.keymap.set({ "i", "n" }, km.popup_submit, submit, { buffer = text_popup.bufnr, noremap = true })
+  end
   vim.keymap.set("n", "<CR>", submit, { buffer = text_popup.bufnr, noremap = true })
+
+  -- Cancel
   vim.keymap.set("n", "<Esc>", close, { buffer = text_popup.bufnr, noremap = true })
-  vim.keymap.set("n", "q", close, { buffer = text_popup.bufnr, noremap = true })
+  if km.popup_cancel then
+    vim.keymap.set("n", km.popup_cancel, close, { buffer = text_popup.bufnr, noremap = true })
+  end
 end
 
 return M


### PR DESCRIPTION
## Summary

- Fix: Call `stopinsert` after restoring focus to prevent being left in insert mode after submitting a comment
- Make popup keymaps configurable via `keymaps` config
- Submit (`<C-s>` by default) now works in both insert and normal mode

## New Keymap Options

| Option | Default | Action |
|--------|---------|--------|
| `popup_submit` | `<C-s>` | Submit comment (insert & normal mode) |
| `popup_cancel` | `q` | Cancel comment (normal mode) |
| `popup_cycle_type` | `<Tab>` | Cycle comment type |

## Example

```lua
require("review").setup({
  keymaps = {
    popup_submit = "<C-j>",  -- custom submit key
  },
})
```