### PR TITLE
fix: prevent FileType autocmd conflicts with render-markdown.nvim

### DIFF
--- a/lua/review/hooks.lua
+++ b/lua/review/hooks.lua
@@ -10,7 +10,10 @@ local current_tabpage = nil
 ---@type number|nil Autocmd group for buffer events
 local buf_augroup = nil
 
----Set filetype for a buffer based on file path
+---Set syntax highlighting for a buffer based on file path.
+---Uses treesitter directly instead of setting filetype to avoid triggering
+---FileType autocmds that other plugins (e.g. render-markdown.nvim) use to
+---attach to buffers, which can interfere with review popups.
 ---@param bufnr number
 ---@param path string|nil
 local function set_buffer_filetype(bufnr, path)
@@ -21,10 +24,16 @@ local function set_buffer_filetype(bufnr, path)
     return
   end
 
-  -- Use Neovim's built-in filetype detection
   local ft = vim.filetype.match({ filename = path, buf = bufnr })
   if ft then
-    vim.api.nvim_set_option_value("filetype", ft, { buf = bufnr })
+    -- Try to use treesitter directly for syntax highlighting without
+    -- triggering FileType autocmds from other plugins
+    local lang = vim.treesitter.language.get_lang(ft) or ft
+    local ts_ok = pcall(vim.treesitter.start, bufnr, lang)
+    if not ts_ok then
+      -- Fallback: set filetype if treesitter doesn't support the language
+      vim.api.nvim_set_option_value("filetype", ft, { buf = bufnr })
+    end
   end
 end
 

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -317,6 +317,9 @@ function M.setup_keymaps(tabpage)
     group = augroup,
     callback = function()
       if vim.api.nvim_get_current_tabpage() ~= tabpage then return end
+      -- Skip floating windows (popups) to avoid overriding their keymaps
+      local win_config = vim.api.nvim_win_get_config(0)
+      if win_config.relative ~= "" then return end
       if not lifecycle.get_session(tabpage) then return end
       set_buffer_keymaps(vim.api.nvim_get_current_buf())
     end,


### PR DESCRIPTION
## Summary

When reviewing markdown files, `set_buffer_filetype` in `hooks.lua` sets `filetype = "markdown"` on the codediff buffers. This triggers `FileType` autocmds that other plugins listen to. In particular, [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) attaches to the buffer and sets up `BufLeave`, `ModeChanged`, and other autocmds. When the user presses `i` to open the comment popup:

1. `BufLeave` fires on the markdown buffer as focus moves to the popup
2. render-markdown.nvim schedules a re-render via `vim.schedule()`
3. The scheduled callback interferes with the popup's focus

Additionally, the `BufEnter` autocmd in `keymaps.lua` was applying review keymaps to floating windows (including the comment popup), overriding the popup's own keymaps for submit/cancel/cycle.

## Changes

- **`hooks.lua`**: Use `vim.treesitter.start(bufnr, lang)` instead of setting the filetype. This provides syntax highlighting via treesitter without triggering `FileType` autocmds from other plugins. Falls back to setting the filetype if treesitter doesn't have a parser for the language.
- **`keymaps.lua`**: Check `vim.api.nvim_win_get_config(0).relative ~= ""` in the `BufEnter` autocmd to skip floating windows (popups).

## Test plan

- [ ] Open `:Review` on a commit that includes `.md` file changes with `render-markdown.nvim` installed
- [ ] Press `i` to open the comment popup — it should stay focused and accept input
- [ ] Submit a comment with `<C-s>` — it should work normally
- [ ] Verify syntax highlighting still works on codediff buffers for various file types


This is the result:


https://github.com/user-attachments/assets/bb4bfa1a-887e-4053-ae7f-fd99109ee2d4


