### PR TITLE
fix: prevent focus stealing on file select and keymaps leaking to explorer

### DIFF
--- a/lua/review/hooks.lua
+++ b/lua/review/hooks.lua
@@ -256,6 +256,26 @@ function M.on_file_changed(tabpage)
     return
   end
 
+  local orig_buf, mod_buf = lifecycle.get_buffers(tabpage)
+
+  -- Set syntax highlighting for the new file's buffers
+  local raw_orig_path, raw_mod_path = lifecycle.get_paths(tabpage)
+  set_buffer_filetype(orig_buf, raw_orig_path)
+  set_buffer_filetype(mod_buf, raw_mod_path)
+
+  -- Make buffers readonly if configured
+  local cfg = config.get()
+  if cfg.codediff.readonly then
+    if orig_buf and vim.api.nvim_buf_is_valid(orig_buf) then
+      vim.api.nvim_set_option_value("modifiable", false, { buf = orig_buf })
+      vim.api.nvim_set_option_value("readonly", true, { buf = orig_buf })
+    end
+    if mod_buf and vim.api.nvim_buf_is_valid(mod_buf) then
+      vim.api.nvim_set_option_value("modifiable", false, { buf = mod_buf })
+      vim.api.nvim_set_option_value("readonly", true, { buf = mod_buf })
+    end
+  end
+
   -- Re-render comments
   vim.defer_fn(function()
     marks.refresh()

--- a/lua/review/init.lua
+++ b/lua/review/init.lua
@@ -43,7 +43,7 @@ function M.setup(opts)
   -- Re-setup hooks when codediff recreates buffers (e.g. layout toggle)
   vim.api.nvim_create_autocmd("User", {
     group = augroup,
-    pattern = { "CodeDiffOpen", "CodeDiffFileSelect" },
+    pattern = "CodeDiffOpen",
     callback = function()
       vim.defer_fn(function()
         M._check_codediff_session()
@@ -51,7 +51,35 @@ function M.setup(opts)
     end,
   })
 
+  -- On file selection, only refresh marks and keymaps — don't refocus
+  vim.api.nvim_create_autocmd("User", {
+    group = augroup,
+    pattern = "CodeDiffFileSelect",
+    callback = function()
+      vim.defer_fn(function()
+        M._on_file_select()
+      end, 100)
+    end,
+  })
+
   initialized = true
+end
+
+-- Handle file selection: refresh hooks/keymaps without stealing focus
+function M._on_file_select()
+  local ok, lifecycle = pcall(require, "codediff.ui.lifecycle")
+  if not ok then
+    return
+  end
+
+  local tabpage = vim.api.nvim_get_current_tabpage()
+  local sess = lifecycle.get_session(tabpage)
+  if not sess then
+    return
+  end
+
+  hooks.on_file_changed(tabpage)
+  keymaps.setup_keymaps(tabpage)
 end
 
 -- Check if current tab is a CodeDiff session and set up hooks/keymaps

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -312,13 +312,20 @@ function M.setup_keymaps(tabpage)
   -- Set keymaps on current buffer
   set_buffer_keymaps(vim.api.nvim_get_current_buf())
 
-  -- Set up autocmd to apply keymaps when entering any buffer in this tabpage
+  -- Set up autocmd to apply keymaps only on codediff diff buffers
   vim.api.nvim_create_autocmd("BufEnter", {
     group = augroup,
     callback = function()
       if vim.api.nvim_get_current_tabpage() ~= tabpage then return end
+      -- Skip floating windows (popups) to avoid overriding their keymaps
+      local win_config = vim.api.nvim_win_get_config(0)
+      if win_config.relative ~= "" then return end
       if not lifecycle.get_session(tabpage) then return end
-      set_buffer_keymaps(vim.api.nvim_get_current_buf())
+      -- Only apply review keymaps to codediff diff buffers, not the explorer
+      local bufnr = vim.api.nvim_get_current_buf()
+      local orig_buf, mod_buf = lifecycle.get_buffers(tabpage)
+      if bufnr ~= orig_buf and bufnr ~= mod_buf then return end
+      set_buffer_keymaps(bufnr)
     end,
   })
 end


### PR DESCRIPTION
## Summary

Two related issues that break navigation between the explorer and diff panes:

### 1. Focus stealing on file selection

Both `CodeDiffOpen` and `CodeDiffFileSelect` events trigger `_check_codediff_session()`, which calls `on_session_created()`, which calls `_focus_modified_pane()` with a 150ms `vim.defer_fn`. This means **every file selection** in the explorer steals focus back to the diff pane ~250ms later. If the user navigates to the explorer with `<C-w>h` (or tmux-navigator's `<C-h>`), the deferred focus call undoes the navigation.

### 2. Review keymaps override explorer keymaps

The `BufEnter` autocmd in `keymaps.lua` applies review keymaps to **all** buffers in the codediff tabpage, including the explorer buffer. This overrides codediff's own explorer keymaps:
- `i` (toggle view mode) → becomes `i` (add comment)
- `q` (quit) → becomes `q` (close review & export)
- `c` (toggle changes) → becomes `c` (list comments)
- etc.

## Changes

- **`init.lua`**: Handle `CodeDiffFileSelect` separately with a new `_on_file_select()` method that calls `hooks.on_file_changed()` and `keymaps.setup_keymaps()` — refreshes everything without calling `_focus_modified_pane()`.
- **`hooks.lua`**: Enhanced `on_file_changed()` to also set up syntax highlighting and readonly state on the new file's buffers (previously it only refreshed marks).
- **`keymaps.lua`**: The `BufEnter` autocmd now checks `lifecycle.get_buffers()` and only applies review keymaps to the original/modified diff buffers, skipping the explorer and floating windows.

## Test plan

- [ ] Open `:Review` on a multi-file commit
- [ ] Navigate to the explorer with `<C-w>h` — focus should stay on the explorer
- [ ] Select a different file in the explorer with `<CR>` — diff should update, focus should move to diff pane (codediff's own behavior)
- [ ] Navigate back to explorer — should work reliably without focus being stolen
- [ ] In the explorer, press `i` — should toggle view mode (list/tree), not open comment popup
- [ ] In the explorer, press `q` — should quit the diff view normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before: (cursor jump are not mine)

https://github.com/user-attachments/assets/ae061d3a-bb9e-43d5-8b01-80b811bd23d2

After: no random jump !

https://github.com/user-attachments/assets/287a8a53-2eeb-4593-b5e6-b30f77489949

