### PR TITLE
fix: Preserve review diff focus

### DIFF
--- a/lua/review/hooks.lua
+++ b/lua/review/hooks.lua
@@ -226,6 +226,9 @@ function M.on_session_created(tabpage)
 end
 
 function M._focus_modified_pane(lifecycle, tabpage)
+  if vim.api.nvim_get_current_tabpage() ~= tabpage then
+    return
+  end
   local current_win = vim.api.nvim_get_current_win()
   local cur_cfg = vim.api.nvim_win_get_config(current_win)
   if cur_cfg.relative ~= "" then

--- a/lua/review/hooks.lua
+++ b/lua/review/hooks.lua
@@ -226,11 +226,23 @@ function M.on_session_created(tabpage)
 end
 
 function M._focus_modified_pane(lifecycle, tabpage)
-  local cur_cfg = vim.api.nvim_win_get_config(vim.api.nvim_get_current_win())
+  local current_win = vim.api.nvim_get_current_win()
+  local cur_cfg = vim.api.nvim_win_get_config(current_win)
   if cur_cfg.relative ~= "" then
     return
   end
   local sess = lifecycle.get_session(tabpage)
+  if not sess then
+    return
+  end
+  if sess.original_win and vim.api.nvim_win_is_valid(sess.original_win) and current_win == sess.original_win then
+    return
+  end
+  local explorer = lifecycle.get_explorer and lifecycle.get_explorer(tabpage)
+  local explorer_win = explorer and explorer.split and explorer.split.winid
+  if explorer_win and vim.api.nvim_win_is_valid(explorer_win) and current_win == explorer_win then
+    return
+  end
   if sess and sess.modified_win and vim.api.nvim_win_is_valid(sess.modified_win) then
     vim.api.nvim_set_current_win(sess.modified_win)
   end

--- a/tests/hooks_focus_spec.lua
+++ b/tests/hooks_focus_spec.lua
@@ -2,10 +2,11 @@ local hooks = require("review.hooks")
 
 describe("hooks focus behavior", function()
   local mod_buf, mod_win, orig_buf, orig_win
-  local extra_bufs
+  local extra_bufs, extra_tabs
 
   before_each(function()
     extra_bufs = {}
+    extra_tabs = {}
 
     -- Model the CodeDiff side-by-side layout closely enough for focus rules:
     -- an original pane on the left and a modified pane on the right.
@@ -24,6 +25,13 @@ describe("hooks focus behavior", function()
   end)
 
   after_each(function()
+    for _, tabpage in ipairs(extra_tabs) do
+      if vim.api.nvim_tabpage_is_valid(tabpage) then
+        vim.api.nvim_set_current_tabpage(tabpage)
+        vim.cmd("tabclose")
+      end
+    end
+
     -- Close windows before deleting buffers so Neovim does not retarget
     -- displayed buffers into another test's window layout.
     while #vim.api.nvim_tabpage_list_wins(0) > 1 do
@@ -91,6 +99,28 @@ describe("hooks focus behavior", function()
     assert.equals(orig_win, vim.api.nvim_get_current_win())
 
     vim.api.nvim_win_get_config = original_get_config
+  end)
+
+  it("should not steal focus from another tab", function()
+    local review_tabpage = vim.api.nvim_get_current_tabpage()
+
+    -- _focus_modified_pane is scheduled with a delay, so the user may leave
+    -- the review tab before the callback runs.
+    vim.cmd("tabnew")
+    local other_tabpage = vim.api.nvim_get_current_tabpage()
+    local other_win = vim.api.nvim_get_current_win()
+    table.insert(extra_tabs, other_tabpage)
+
+    local lifecycle = {
+      get_session = function()
+        return { original_win = orig_win, modified_win = mod_win }
+      end,
+    }
+
+    hooks._focus_modified_pane(lifecycle, review_tabpage)
+
+    assert.equals(other_tabpage, vim.api.nvim_get_current_tabpage())
+    assert.equals(other_win, vim.api.nvim_get_current_win())
   end)
 
   it("should not steal focus from the original pane", function()

--- a/tests/hooks_focus_spec.lua
+++ b/tests/hooks_focus_spec.lua
@@ -1,13 +1,22 @@
 local hooks = require("review.hooks")
 
 describe("hooks focus behavior", function()
-  local mod_buf, mod_win, other_win
+  local mod_buf, mod_win, orig_buf, orig_win
+  local extra_bufs
 
   before_each(function()
+    extra_bufs = {}
+
+    -- Model the CodeDiff side-by-side layout closely enough for focus rules:
+    -- an original pane on the left and a modified pane on the right.
+    orig_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(orig_buf, 0, -1, false, { "old line" })
+
     mod_buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(mod_buf, 0, -1, false, { "new line" })
 
-    other_win = vim.api.nvim_get_current_win()
+    orig_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(orig_win, orig_buf)
 
     vim.cmd("vsplit")
     mod_win = vim.api.nvim_get_current_win()
@@ -15,23 +24,40 @@ describe("hooks focus behavior", function()
   end)
 
   after_each(function()
+    -- Close windows before deleting buffers so Neovim does not retarget
+    -- displayed buffers into another test's window layout.
+    while #vim.api.nvim_tabpage_list_wins(0) > 1 do
+      vim.cmd("quit")
+    end
+
+    for _, bufnr in ipairs(extra_bufs) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    if vim.api.nvim_buf_is_valid(orig_buf) then
+      vim.api.nvim_buf_delete(orig_buf, { force = true })
+    end
     if vim.api.nvim_buf_is_valid(mod_buf) then
       vim.api.nvim_buf_delete(mod_buf, { force = true })
     end
 
-    while #vim.api.nvim_tabpage_list_wins(0) > 1 do
-      vim.cmd("quit")
-    end
   end)
 
   it("focuses the modified pane normally", function()
     local tabpage = vim.api.nvim_get_current_tabpage()
-    vim.api.nvim_set_current_win(other_win)
-    assert.equals(other_win, vim.api.nvim_get_current_win())
+
+    -- Initial review setup may still move focus from unrelated windows into
+    -- the modified pane; only CodeDiff-owned panes should be protected.
+    local other_buf = vim.api.nvim_create_buf(false, true)
+    table.insert(extra_bufs, other_buf)
+    vim.cmd("vsplit")
+    local other_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(other_win, other_buf)
 
     local lifecycle = {
       get_session = function()
-        return { modified_win = mod_win }
+        return { original_win = orig_win, modified_win = mod_win }
       end,
     }
 
@@ -42,7 +68,7 @@ describe("hooks focus behavior", function()
 
   it("should not steal focus from floating windows", function()
     local tabpage = vim.api.nvim_get_current_tabpage()
-    vim.api.nvim_set_current_win(other_win)
+    vim.api.nvim_set_current_win(orig_win)
 
     local lifecycle = {
       get_session = function()
@@ -62,8 +88,45 @@ describe("hooks focus behavior", function()
     hooks._focus_modified_pane(lifecycle, tabpage)
 
     -- Focus should stay on the current window, not jump to mod_win
-    assert.equals(other_win, vim.api.nvim_get_current_win())
+    assert.equals(orig_win, vim.api.nvim_get_current_win())
 
     vim.api.nvim_win_get_config = original_get_config
+  end)
+
+  it("should not steal focus from the original pane", function()
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    vim.api.nvim_set_current_win(orig_win)
+
+    local lifecycle = {
+      get_session = function()
+        return { original_win = orig_win, modified_win = mod_win }
+      end,
+    }
+
+    hooks._focus_modified_pane(lifecycle, tabpage)
+
+    assert.equals(orig_win, vim.api.nvim_get_current_win())
+  end)
+
+  it("should not steal focus from the explorer window", function()
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    vim.cmd("vsplit")
+    local explorer_win = vim.api.nvim_get_current_win()
+
+    local lifecycle = {
+      get_explorer = function()
+        -- _focus_modified_pane only needs the explorer split's window id,
+        -- matching the CodeDiff explorer object shape used by review.nvim.
+        return { split = { winid = explorer_win } }
+      end,
+      get_session = function()
+        return { original_win = orig_win, modified_win = mod_win }
+      end,
+    }
+
+    vim.api.nvim_set_current_win(explorer_win)
+    hooks._focus_modified_pane(lifecycle, tabpage)
+
+    assert.equals(explorer_win, vim.api.nvim_get_current_win())
   end)
 end)


### PR DESCRIPTION
Problem

Selecting a file in the CodeDiff explorer,
or moving focus to the original side of the diff,
could jump focus back to the modified side shortly afterward.

Cause

The focus jump came from session setup.
review.nvim reruns session setup after CodeDiffFileSelect,
then schedules _focus_modified_pane() with a short delay.

That delayed callback did not distinguish initial session focus
from later user-selected CodeDiff windows,
so it overrode CodeDiff's own explorer focus behavior.

Fix

_focus_modified_pane() now keeps focus in place when the current window
is a floating window, the CodeDiff explorer, or the original diff pane.

It still focuses the modified pane from unrelated windows,
preserving the initial right-pane focus behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unwanted focus jumps in review diffs and keeps focus within the review tab. Moves to the modified pane only during initial setup or from unrelated windows.

- **Bug Fixes**
  - Updated `_focus_modified_pane()` to no-op when the current window is floating, the explorer, the original pane, or a different tab; safely handles missing sessions.
  - Preserves initial right-pane focus by only redirecting from unrelated windows in the review tab.
  - Added tests for explorer, original pane, floating window, and other-tab scenarios; tightened window/buffer cleanup to avoid cross-test interference.

<sup>Written for commit ad7f4193d2cfe69854465402f1ac90a691aec317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/review.nvim/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

