### PR TITLE
fix: show configured popup submit key

### DIFF
--- a/lua/review/popup.lua
+++ b/lua/review/popup.lua
@@ -31,6 +31,8 @@ function M.open(initial_type, initial_text, callback)
   local type_keys = { "note", "suggestion", "issue", "praise" }
   local current_type_idx = 1
 
+  local submit_hint = cfg.keymaps.popup_submit and string.format(" (%s: submit)", cfg.keymaps.popup_submit) or ""
+
   -- Find initial type index
   if initial_type then
     for i, key in ipairs(type_keys) do
@@ -60,7 +62,7 @@ function M.open(initial_type, initial_text, callback)
     border = {
       style = "rounded",
       text = {
-        top = " Comment (C-s: submit) ",
+        top = " Comment" .. submit_hint .. " ",
         top_align = "center",
       },
     },


### PR DESCRIPTION
## Summary

- derive the comment popup submit hint from `keymaps.popup_submit`
- omit the hint when popup submission is disabled
- prevent custom submit mappings from leaving a stale `C-s` label

## Testing

- `make test` (121 tests passed)
- `stylua --check --indent-type Spaces --indent-width 2 lua/review/popup.lua`
- headless Neovim smoke test with `<C-CR>` as the configured mapping

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the comment popup submit hint to show the configured `keymaps.popup_submit` binding instead of a hardcoded `C-s` label. When popup submission is disabled, the hint is omitted entirely, so custom mappings no longer leave a stale `C-s` label on the border.

<sup>Written for commit db3bd607edf25d1f78d781c8ba40a16e227598ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/review.nvim/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

