### PR TITLE
Try to fix keymap unreliability between codediff.nvim and review.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For multi-line comments, visually select the range first then press `i`. For fil
 
 Use `]n` and `[n` to jump between comments, `e` to edit one, `d` to delete. Press `c` to see a list of all comments across files and jump to any of them.
 
-When you're done, press `q` to close the review. This automatically copies all your comments to the clipboard as structured markdown and shows a preview. Paste it into Claude Code, sidekick.nvim (`S`), or wherever you're chatting with an AI. The format looks like this:
+When you're done, press `q` to close the review. This automatically copies all your comments to the clipboard as structured markdown and shows a preview. (On diff panes `q` is review's export-and-close, overriding codediff's plain quit.) Paste it into Claude Code, sidekick.nvim (`S`), or wherever you're chatting with an AI. The format looks like this:
 
 ```
 1. **[ISSUE]** `src/api.ts:23` - This endpoint doesn't handle errors
@@ -82,6 +82,10 @@ When you're done, press `q` to close the review. This automatically copies all y
 Lines prefixed with `~` refer to the old (left) side of the diff. Comments persist per branch, so you can close Neovim and come back to the same review later. Sessions auto-expire after 7 days.
 
 ## Keybindings (in diff view)
+
+Review's maps below are buffer-local to the diff panes only. The
+file explorer/history panels keep codediff's own keys (`i`, `S`, `R`,
+`<CR>`, folds, …) — review never shadows them there.
 
 **Readonly mode** (default):
 | Key | Action |
@@ -99,9 +103,23 @@ Lines prefixed with `~` refer to the old (left) side of the diff. Comments persi
 | `C` | Export to clipboard and show preview |
 | `S` | Send comments to sidekick.nvim |
 | `<C-r>` | Clear all comments |
-| `q` | Close and export comments to clipboard |
+| `q` | Export & close review (overrides codediff's quit, see below) |
+| `?` | Show review help |
+
+**Codediff's own keys** (still available on diff panes — learn these too):
+| Key | Action |
+|-----|--------|
 | `t` | Toggle side-by-side/inline layout |
 | `g?` | Show codediff help |
+| `]c` / `[c` | Next/previous hunk |
+| `]f` / `[f` | Next/previous file |
+| `do` / `dp` | Get/put change (like vimdiff) |
+
+**About `q`:** on diff panes, `q` is review's export-and-close — it
+deliberately overrides codediff's quit-without-export so `:Review`
+sessions always export. On file panels (where review installs no maps),
+`q` remains codediff's plain close. If you customize either side's maps
+into a silent overlap, `setup()` warns you immediately.
 
 **Edit mode** (when `readonly = false`):
 | Key | Action |
@@ -116,7 +134,7 @@ Lines prefixed with `~` refer to the old (left) side of the diff. Comments persi
 |-----|--------|
 | `Enter` | Insert newline (multi-line comments supported) |
 | `Ctrl+s` | Submit comment |
-| `Tab` | Cycle comment type |
+| `Tab` | Cycle comment type (separate popup buffer — no conflict with next-file `<Tab>`) |
 | `Esc` / `q` | Cancel (normal mode) |
 
 ## Configuration

--- a/doc/review.txt
+++ b/doc/review.txt
@@ -179,10 +179,19 @@ ACTIONS                                               *review-keymaps-actions*
     `S`           Send to sidekick.nvim                  |n|
     `<C-r>`       Clear all comments                     |n|
     `R`           Toggle readonly/edit mode               |n|
-    `q`           Export & close review                   |n|
+    `q`           Export & close review (overrides        |n|
+                  codediff's quit on diff panes)         |n|
     `?`           Show help popup                         |n|
-    `t`           Toggle layout (side-by-side/inline)     |n|
-    `g?`          Show codediff help                      |n|
+
+COEXISTENCE WITH CODEDIFF                      *review-keymaps-codediff*
+
+Review maps are buffer-local to the diff panes only; explorer/history
+panels keep codediff's own keys (`i`, `S`, `R`, `<CR>`, folds, ...).
+On diff panes, `q` is review's export-and-close and deliberately
+overrides codediff's quit-without-export (claimed at higher priority
+in the session keymap registry). Codediff natives worth knowing:
+`t` (layout), `g?` (help), `]c`/`[c` (hunks), `]f`/`[f` (files),
+`do`/`dp` (get/put change). Custom overlaps warn at setup().
 
 POPUP                                                 *review-keymaps-popup*
 

--- a/lua/review/config.lua
+++ b/lua/review/config.lua
@@ -95,9 +95,107 @@ M.defaults = {
 ---@type ReviewConfig
 M.config = vim.deepcopy(M.defaults)
 
+-- Review keymaps that never touch diff buffers (popup-local) and are
+-- therefore excluded from conflict detection.
+local NON_DIFF_KEYMAPS = {
+  popup_submit = true,
+  popup_cancel = true,
+  popup_cycle_type = true,
+}
+
+-- Deliberate overrides skipped by conflict detection:
+-- { [review_key] = { role = <codediff role>, name = <codediff name> } }.
+-- Review's close intentionally shadows codediff's view.quit on diff buffers
+-- via a priority registry claim (see keymaps.lua).
+local KNOWN_OVERRIDES = {
+  close = { role = "view", name = "quit" },
+}
+
+--- Flatten one codediff keymap role to a list of { name, lhs }.
+---@param role_maps table|nil
+---@return { name: string, lhs: string }[]
+local function flatten_role(role_maps)
+  local out = {}
+  if type(role_maps) ~= "table" then
+    return out
+  end
+  for name, lhs in pairs(role_maps) do
+    for _, key in ipairs(type(lhs) == "table" and lhs or { lhs }) do
+      if type(key) == "string" and key ~= "" then
+        table.insert(out, { name = name, lhs = key })
+      end
+    end
+  end
+  return out
+end
+
+--- Best-effort canonicalization so equivalent spellings compare equal.
+---@param lhs string
+---@return string
+local function canonical(lhs)
+  local ok, normalize = pcall(require, "codediff.keymap.normalize")
+  if ok and normalize and normalize.canonical then
+    local ok2, result = pcall(normalize.canonical, lhs)
+    if ok2 and result then
+      return result
+    end
+  end
+  return lhs
+end
+
+--- Compare resolved review maps against the codediff roles that land on
+--- diff buffers (view is tab-wide, conflict is diff/result scoped) and warn
+--- about silent shadowing. Silently returns {} when codediff is absent.
+---@return string[] overlaps human-readable overlap descriptions
+function M.check_codediff_conflicts()
+  local ok, codediff_config = pcall(require, "codediff.config")
+  if not ok or type(codediff_config) ~= "table" then
+    return {}
+  end
+  local keymaps = codediff_config.options and codediff_config.options.keymaps
+  if type(keymaps) ~= "table" then
+    return {}
+  end
+
+  local codediff_maps = {}
+  for _, role in ipairs({ "view", "conflict" }) do
+    for _, entry in ipairs(flatten_role(keymaps[role])) do
+      table.insert(codediff_maps, { role = role, name = entry.name, lhs = entry.lhs })
+    end
+  end
+
+  local overlaps = {}
+  for review_key, lhs in pairs(M.config.keymaps) do
+    if not NON_DIFF_KEYMAPS[review_key] and type(lhs) == "string" and lhs ~= "" then
+      for _, cm in ipairs(codediff_maps) do
+        if canonical(lhs) == canonical(cm.lhs) then
+          local override = KNOWN_OVERRIDES[review_key]
+          if not (override and override.role == cm.role and override.name == cm.name) then
+            table.insert(
+              overlaps,
+              string.format("keymaps.%s (%s) overlaps codediff %s.%s", review_key, lhs, cm.role, cm.name)
+            )
+          end
+        end
+      end
+    end
+  end
+  table.sort(overlaps)
+
+  if #overlaps > 0 then
+    vim.notify(
+      "review.nvim keymap conflict(s) with codediff.nvim:\n- " .. table.concat(overlaps, "\n- "),
+      vim.log.levels.WARN,
+      { title = "review.nvim" }
+    )
+  end
+  return overlaps
+end
+
 ---@param opts? ReviewConfig
 function M.setup(opts)
   M.config = vim.tbl_deep_extend("force", M.defaults, opts or {})
+  M.check_codediff_conflicts()
 end
 
 ---@return ReviewConfig

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -180,10 +180,33 @@ local function show_help()
   help_popup:map("n", "<Esc>", close_help, map_opts)
 end
 
+--- True when bufnr is a diff buffer owned by the session.
+--- Explorer/history panels are intentionally excluded: codediff owns the
+--- keys there (e.g. i/S/R) and review must not shadow them.
+---@param lifecycle table
+---@param tabpage number
 ---@param bufnr number
-local function set_buffer_keymaps(bufnr)
+---@return boolean
+local function is_diff_buffer(lifecycle, tabpage, bufnr)
+  if lifecycle.find_tabpage_by_buffer then
+    -- Matches original/modified/result buffers only, never panel buffers.
+    -- Covers inline layout (same session buffers) and conflict mode.
+    return lifecycle.find_tabpage_by_buffer(bufnr) == tabpage
+  end
+  local orig_buf, mod_buf = lifecycle.get_buffers(tabpage)
+  return bufnr == orig_buf or bufnr == mod_buf
+end
+
+---@param tabpage number
+---@param bufnr number
+local function set_buffer_keymaps(tabpage, bufnr)
   -- Clear existing keymaps first
   clear_buffer_keymaps(bufnr)
+
+  local ok, lifecycle = pcall(require, "codediff.ui.lifecycle")
+  if ok and not is_diff_buffer(lifecycle, tabpage, bufnr) then
+    return
+  end
 
   local cfg = config.get()
   local km = cfg.keymaps
@@ -310,7 +333,7 @@ function M.setup_keymaps(tabpage)
   keymapped_buffers = {}
 
   -- Set keymaps on current buffer
-  set_buffer_keymaps(vim.api.nvim_get_current_buf())
+  set_buffer_keymaps(tabpage, vim.api.nvim_get_current_buf())
 
   -- Set up autocmd to apply keymaps when entering any buffer in this tabpage
   vim.api.nvim_create_autocmd("BufEnter", {
@@ -318,7 +341,8 @@ function M.setup_keymaps(tabpage)
     callback = function()
       if vim.api.nvim_get_current_tabpage() ~= tabpage then return end
       if not lifecycle.get_session(tabpage) then return end
-      set_buffer_keymaps(vim.api.nvim_get_current_buf())
+      -- Panel buffers are skipped inside set_buffer_keymaps
+      set_buffer_keymaps(tabpage, vim.api.nvim_get_current_buf())
     end,
   })
 end
@@ -345,6 +369,7 @@ M._test = {
   format_key = format_key,
   add_section = add_section,
   is_enabled = is_enabled,
+  is_diff_buffer = is_diff_buffer,
 }
 
 return M

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -7,6 +7,15 @@ local export = require("review.export")
 -- Track which buffers have keymaps set and what keys were mapped
 local keymapped_buffers = {}
 
+-- Tabpage the tracked keymaps belong to. Review assumes a single active
+-- review tab, matching the existing global BufEnter autocmd design.
+local active_tabpage = nil
+
+-- Priority of review's close map inside codediff's slot arbiter. Codediff
+-- claims view.quit ("q") at default priority; review deliberately overrides
+-- it on diff buffers so q always means export-and-close in a Review session.
+local CLOSE_PRIORITY = 10
+
 --- Check if a keymap is enabled (not false, nil, or empty string)
 ---@param key string|false|nil
 ---@return boolean
@@ -14,12 +23,47 @@ local function is_enabled(key)
   return key ~= nil and key ~= false and key ~= ""
 end
 
+--- Install one mapping, owned by the codediff session registry when possible.
+--- Registry ownership means layout toggles retire/reinstall review maps
+--- alongside codediff's instead of racing them. Falls back to a plain
+--- buffer-local map when codediff is unavailable.
+---@param tabpage number
+---@param bufnr number
+---@param mode string
+---@param lhs string|false|nil
+---@param rhs function|string
+---@param desc string
+---@param priority number|nil
+---@return {string, string}|nil tracked entry on success
+local function install_keymap(tabpage, bufnr, mode, lhs, rhs, desc, priority)
+  if not is_enabled(lhs) then
+    return nil
+  end
+  local opts = { noremap = true, silent = true, nowait = true, desc = desc }
+  local ok, lifecycle = pcall(require, "codediff.ui.lifecycle")
+  if ok and lifecycle.set_buf_keymap then
+    local meta = priority and { priority = priority } or nil
+    if lifecycle.set_buf_keymap(tabpage, bufnr, mode, lhs, rhs, opts, meta) then
+      return { mode, lhs }
+    end
+    return nil
+  end
+  vim.keymap.set(mode, lhs, rhs, vim.tbl_extend("force", opts, { buffer = bufnr }))
+  return { mode, lhs }
+end
+
 --- Delete a keymap from a buffer if it exists
+---@param tabpage number
 ---@param bufnr number
 ---@param mode string
 ---@param lhs string|nil
-local function del_keymap(bufnr, mode, lhs)
+local function del_keymap(tabpage, bufnr, mode, lhs)
   if lhs and vim.api.nvim_buf_is_valid(bufnr) then
+    local ok, lifecycle = pcall(require, "codediff.ui.lifecycle")
+    if ok and tabpage and lifecycle.del_buf_keymap then
+      lifecycle.del_buf_keymap(tabpage, bufnr, mode, lhs)
+      return
+    end
     pcall(vim.keymap.del, mode, lhs, { buffer = bufnr })
   end
 end
@@ -30,7 +74,7 @@ local function clear_buffer_keymaps(bufnr)
   local tracked = keymapped_buffers[bufnr]
   if tracked then
     for _, entry in ipairs(tracked) do
-      del_keymap(bufnr, entry[1], entry[2])
+      del_keymap(active_tabpage, bufnr, entry[1], entry[2])
     end
   end
 end
@@ -213,17 +257,17 @@ local function set_buffer_keymaps(tabpage, bufnr)
   local readonly = cfg.codediff.readonly
   local mapped = {}
 
-  local function set(lhs, rhs, desc)
-    if is_enabled(lhs) then
-      vim.keymap.set("n", lhs, rhs, { buffer = bufnr, noremap = true, silent = true, nowait = true, desc = desc })
-      table.insert(mapped, { "n", lhs })
+  local function set(lhs, rhs, desc, priority)
+    local entry = install_keymap(tabpage, bufnr, "n", lhs, rhs, desc, priority)
+    if entry then
+      table.insert(mapped, entry)
     end
   end
 
-  local function set_visual(lhs, rhs, desc)
-    if is_enabled(lhs) then
-      vim.keymap.set("x", lhs, rhs, { buffer = bufnr, noremap = true, silent = true, nowait = true, desc = desc })
-      table.insert(mapped, { "x", lhs })
+  local function set_visual(lhs, rhs, desc, priority)
+    local entry = install_keymap(tabpage, bufnr, "x", lhs, rhs, desc, priority)
+    if entry then
+      table.insert(mapped, entry)
     end
   end
 
@@ -302,7 +346,9 @@ local function set_buffer_keymaps(tabpage, bufnr)
       require("codediff.ui.explorer").toggle_visibility(explorer_obj)
     end
   end, "Toggle file panel")
-  set(km.close, function() require("review").close() end, "Close")
+  -- Close deliberately overrides codediff's view.quit on diff buffers so
+  -- q always means export-and-close inside a Review session.
+  set(km.close, function() require("review").close() end, "Close", CLOSE_PRIORITY)
   set(km.toggle_readonly, function() require("review").toggle_readonly() end, "Toggle readonly mode")
   set(km.show_help, show_help, "Show help")
 
@@ -331,6 +377,7 @@ function M.setup_keymaps(tabpage)
     clear_buffer_keymaps(bufnr)
   end
   keymapped_buffers = {}
+  active_tabpage = tabpage
 
   -- Set keymaps on current buffer
   set_buffer_keymaps(tabpage, vim.api.nvim_get_current_buf())
@@ -363,6 +410,7 @@ function M.cleanup()
   end
   close_help()
   M.clear_keymaps()
+  active_tabpage = nil
 end
 
 M._test = {

--- a/lua/review/keymaps.lua
+++ b/lua/review/keymaps.lua
@@ -183,6 +183,8 @@ local function show_help()
   add_section(nav_entries, "Navigation", lines, max_key_width)
   add_section(action_entries, "Actions", lines, max_key_width)
   table.insert(lines, "")
+  table.insert(lines, "  q overrides codediff's quit here: export & close")
+  table.insert(lines, "")
 
   local max_line_width = 0
   for _, line in ipairs(lines) do

--- a/tests/keymap_conflict_spec.lua
+++ b/tests/keymap_conflict_spec.lua
@@ -1,0 +1,61 @@
+local config = require("review.config")
+
+describe("review.config conflict detection", function()
+  local saved_codediff_config
+  local saved_notify
+  local notifications
+
+  before_each(function()
+    config.setup()
+    saved_codediff_config = package.loaded["codediff.config"]
+    saved_notify = vim.notify
+    notifications = {}
+    vim.notify = function(msg, level, opts)
+      table.insert(notifications, { msg = msg, level = level, opts = opts })
+    end
+  end)
+
+  after_each(function()
+    vim.notify = saved_notify
+    package.loaded["codediff.config"] = saved_codediff_config
+    config.setup()
+  end)
+
+  local function stub_codediff(keymaps)
+    package.loaded["codediff.config"] = { options = { keymaps = keymaps } }
+  end
+
+  it("warns when a review map overlaps a codediff view map", function()
+    stub_codediff({ view = { quit = "q", toggle_layout = "t" } })
+    local overlaps = config.check_codediff_conflicts()
+    -- close/q vs view.quit/q is deliberate and excluded
+    assert.equals(0, #overlaps)
+    assert.equals(0, #notifications)
+
+    config.setup({ keymaps = { toggle_readonly = "t" } })
+    assert.equals(1, #notifications)
+    assert.equals(vim.log.levels.WARN, notifications[1].level)
+    assert.matches("toggle_readonly", notifications[1].msg)
+    assert.matches("toggle_layout", notifications[1].msg)
+  end)
+
+  it("stays silent when codediff is unavailable", function()
+    package.loaded["codediff.config"] = nil
+    local overlaps = config.check_codediff_conflicts()
+    assert.equals(0, #overlaps)
+    assert.equals(0, #notifications)
+  end)
+
+  it("ignores popup-local maps and disabled maps", function()
+    stub_codediff({ view = { quit = "q", other = "<C-s>" } })
+    config.setup({ keymaps = { popup_submit = "<C-s>", toggle_readonly = false } })
+    assert.equals(0, #notifications)
+  end)
+
+  it("compares conflict-role maps that land on diff buffers", function()
+    stub_codediff({ conflict = { accept_incoming = "C" } })
+    config.setup({ keymaps = { export_clipboard = "C" } })
+    assert.equals(1, #notifications)
+    assert.matches("export_clipboard", notifications[1].msg)
+  end)
+end)

--- a/tests/keymap_disjoint_spec.lua
+++ b/tests/keymap_disjoint_spec.lua
@@ -1,0 +1,99 @@
+-- The busted harness resets rtp, so opt-in to a real codediff checkout via
+-- CODEDIFF_DIR (e.g. CODEDIFF_DIR=~/.local/share/nvim/lazy/codediff.nvim).
+-- Without it the tests below pending-skip.
+local codediff_dir = os.getenv("CODEDIFF_DIR")
+if codediff_dir and vim.fn.isdirectory(codediff_dir) == 1 then
+  vim.opt.rtp:append(codediff_dir)
+end
+
+local review_config = require("review.config")
+
+-- The test that would have caught this whole class of bug: resolving both
+-- plugins' default keymap tables and asserting no lhs overlap on the same
+-- buffer roles. Fails if either side's defaults drift into collision.
+-- Skipped when codediff.nvim is not on the rtp (e.g. CI); run it in a
+-- real session with both plugins installed.
+describe("review/codediff default disjointness", function()
+  local function codediff_defaults()
+    local ok, cc = pcall(require, "codediff.config")
+    if not ok or type(cc) ~= "table" or type(cc.defaults) ~= "table" then
+      return nil
+    end
+    return cc.defaults.keymaps
+  end
+
+  --- Flatten a codediff role to { lhs -> name }.
+  local function flatten(role_maps)
+    local out = {}
+    if type(role_maps) ~= "table" then
+      return out
+    end
+    for name, lhs in pairs(role_maps) do
+      for _, key in ipairs(type(lhs) == "table" and lhs or { lhs }) do
+        if type(key) == "string" and key ~= "" then
+          out[key] = name
+        end
+      end
+    end
+    return out
+  end
+
+  --- Review defaults that land on diff buffers (popup maps are popup-local).
+  local function review_diff_maps()
+    local out = {}
+    for key, lhs in pairs(review_config.defaults.keymaps) do
+      if not key:match("^popup_") and type(lhs) == "string" and lhs ~= "" then
+        out[lhs] = key
+      end
+    end
+    return out
+  end
+
+  it("has exactly one diff-role overlap: the deliberate q override", function()
+    local cd = codediff_defaults()
+    if not cd then
+      pending("codediff.nvim not on rtp")
+      return
+    end
+
+    local review_maps = review_diff_maps()
+    local overlaps = {}
+    for _, role in ipairs({ "view", "conflict" }) do
+      for lhs, name in pairs(flatten(cd[role])) do
+        if review_maps[lhs] then
+          table.insert(overlaps, { review_key = review_maps[lhs], role = role, name = name, lhs = lhs })
+        end
+      end
+    end
+
+    -- q is deliberately overridden by review's close via a priority
+    -- registry claim. Anything else (or a missing q) means defaults
+    -- drifted and the override contract needs revisiting.
+    assert.equals(1, #overlaps)
+    assert.same({ review_key = "close", role = "view", name = "quit", lhs = "q" }, overlaps[1])
+  end)
+
+  it("keeps panel-role overlaps within the scoped allowlist", function()
+    local cd = codediff_defaults()
+    if not cd then
+      pending("codediff.nvim not on rtp")
+      return
+    end
+
+    -- i/S/R collide with explorer maps but are safe ONLY because review
+    -- never installs maps on panel buffers (see keymap_scope_spec.lua).
+    -- Anything beyond this allowlist must be scoped, not renamed.
+    local allowlist = { i = true, S = true, R = true }
+    local review_maps = review_diff_maps()
+    for _, role in ipairs({ "explorer", "history" }) do
+      for lhs, name in pairs(flatten(cd[role])) do
+        if review_maps[lhs] then
+          assert.is_true(
+            allowlist[lhs],
+            string.format("review keymaps.%s (%s) collides with codediff %s.%s", review_maps[lhs], lhs, role, name)
+          )
+        end
+      end
+    end
+  end)
+end)

--- a/tests/keymap_registry_spec.lua
+++ b/tests/keymap_registry_spec.lua
@@ -1,0 +1,127 @@
+local keymaps = require("review.keymaps")
+local config = require("review.config")
+
+-- Review maps must be installed through codediff's keymap registry
+-- (lifecycle.set_buf_keymap) so layout toggles retire/reinstall them
+-- alongside codediff's own maps instead of racing via vim.keymap.set.
+describe("review.keymaps registry", function()
+  local tabpage
+  local diff1, diff2, panel
+  local saved_lifecycle
+  local installed
+  local removed
+
+  before_each(function()
+    config.setup()
+    tabpage = vim.api.nvim_get_current_tabpage()
+
+    diff1 = vim.api.nvim_create_buf(false, true)
+    diff2 = vim.api.nvim_create_buf(false, true)
+    panel = vim.api.nvim_create_buf(false, true)
+    installed = {}
+    removed = {}
+
+    saved_lifecycle = package.loaded["codediff.ui.lifecycle"]
+    package.loaded["codediff.ui.lifecycle"] = {
+      get_session = function(tab)
+        if tab ~= tabpage then
+          return nil
+        end
+        return { stored_diff_result = { changes = {} } }
+      end,
+      get_buffers = function()
+        return diff1, diff2
+      end,
+      find_tabpage_by_buffer = function(bufnr)
+        if bufnr == diff1 or bufnr == diff2 then
+          return tabpage
+        end
+        return nil
+      end,
+      set_buf_keymap = function(tab, bufnr, mode, lhs, rhs, opts, meta)
+        table.insert(installed, { tab = tab, bufnr = bufnr, mode = mode, lhs = lhs, meta = meta })
+        vim.keymap.set(mode, lhs, rhs, vim.tbl_extend("force", opts or {}, { buffer = bufnr }))
+        return true
+      end,
+      del_buf_keymap = function(tab, bufnr, mode, lhs)
+        table.insert(removed, { tab = tab, bufnr = bufnr, mode = mode, lhs = lhs })
+        pcall(vim.keymap.del, mode, lhs, { buffer = bufnr })
+      end,
+    }
+
+    vim.api.nvim_set_current_buf(diff1)
+    keymaps.setup_keymaps(tabpage)
+  end)
+
+  after_each(function()
+    keymaps.cleanup()
+    package.loaded["codediff.ui.lifecycle"] = saved_lifecycle
+    for _, bufnr in ipairs({ diff1, diff2, panel }) do
+      if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("installs diff-buffer maps via the session registry", function()
+    assert.is_true(#installed > 0)
+    for _, call in ipairs(installed) do
+      assert.equals(tabpage, call.tab)
+      assert.is_true(call.bufnr == diff1 or call.bufnr == diff2)
+    end
+  end)
+
+  it("claims close with priority so it overrides codediff quit", function()
+    local close_calls = vim.tbl_filter(function(call)
+      return call.lhs == "q" and call.mode == "n"
+    end, installed)
+    assert.equals(1, #close_calls)
+    assert.is_not_nil(close_calls[1].meta)
+    assert.is_true(close_calls[1].meta.priority > 0)
+  end)
+
+  it("claims non-colliding maps at default priority", function()
+    local add_calls = vim.tbl_filter(function(call)
+      return call.lhs == "i" and call.mode == "n"
+    end, installed)
+    assert.equals(1, #add_calls)
+    assert.is_nil(add_calls[1].meta)
+  end)
+
+  it("never installs panel maps through the registry", function()
+    vim.api.nvim_set_current_buf(panel)
+    for _, call in ipairs(installed) do
+      assert.is_nil(call.bufnr == panel and true or nil, "panel buffer claimed: " .. call.lhs)
+    end
+  end)
+
+  it("removes maps via the session registry on cleanup", function()
+    keymaps.cleanup()
+    assert.is_true(#removed > 0)
+    assert.equals(#installed, #removed)
+  end)
+
+  it("falls back to plain buffer maps when the registry API is missing", function()
+    keymaps.cleanup()
+    package.loaded["codediff.ui.lifecycle"] = {
+      get_session = function()
+        return {}
+      end,
+      get_buffers = function()
+        return diff1, diff2
+      end,
+      find_tabpage_by_buffer = function(bufnr)
+        if bufnr == diff1 or bufnr == diff2 then
+          return tabpage
+        end
+        return nil
+      end,
+      -- no set_buf_keymap / del_buf_keymap: older codediff
+    }
+    vim.api.nvim_set_current_buf(diff1)
+    keymaps.setup_keymaps(tabpage)
+    vim.api.nvim_set_current_buf(diff1)
+    local map = vim.fn.maparg("i", "n", false, true)
+    assert.is_true(type(map) == "table" and next(map) ~= nil)
+  end)
+end)

--- a/tests/keymap_scope_spec.lua
+++ b/tests/keymap_scope_spec.lua
@@ -1,0 +1,84 @@
+local keymaps = require("review.keymaps")
+local config = require("review.config")
+
+-- Regression test: review keymaps must only land on codediff diff buffers,
+-- never on explorer/history panel buffers where codediff owns keys like
+-- i (toggle_view_mode), S (stage_all) and R (refresh).
+describe("review.keymaps scoping", function()
+  local tabpage
+  local diff1, diff2, panel
+  local saved_lifecycle
+
+  local function buf_maparg(bufnr, lhs, mode)
+    vim.api.nvim_set_current_buf(bufnr)
+    local map = vim.fn.maparg(lhs, mode, false, true)
+    if type(map) ~= "table" or next(map) == nil then
+      return nil
+    end
+    return map
+  end
+
+  before_each(function()
+    config.setup()
+    tabpage = vim.api.nvim_get_current_tabpage()
+
+    diff1 = vim.api.nvim_create_buf(false, true)
+    diff2 = vim.api.nvim_create_buf(false, true)
+    panel = vim.api.nvim_create_buf(false, true)
+
+    saved_lifecycle = package.loaded["codediff.ui.lifecycle"]
+    package.loaded["codediff.ui.lifecycle"] = {
+      get_session = function(tab)
+        if tab ~= tabpage then
+          return nil
+        end
+        return { stored_diff_result = { changes = {} } }
+      end,
+      get_buffers = function()
+        return diff1, diff2
+      end,
+      find_tabpage_by_buffer = function(bufnr)
+        if bufnr == diff1 or bufnr == diff2 then
+          return tabpage
+        end
+        return nil
+      end,
+    }
+
+    vim.api.nvim_set_current_buf(diff1)
+    keymaps.setup_keymaps(tabpage)
+  end)
+
+  after_each(function()
+    keymaps.cleanup()
+    package.loaded["codediff.ui.lifecycle"] = saved_lifecycle
+    for _, bufnr in ipairs({ diff1, diff2, panel }) do
+      if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("applies review maps to diff buffers", function()
+    assert.is_not_nil(buf_maparg(diff1, "i", "n"))
+    assert.is_not_nil(buf_maparg(diff2, "i", "n"))
+    assert.is_not_nil(buf_maparg(diff1, "q", "n"))
+  end)
+
+  it("applies no review maps to panel buffers", function()
+    vim.api.nvim_set_current_buf(panel)
+    for _, lhs in ipairs({ "i", "e", "d", "F", "S", "R", "q", "c", "C", "f" }) do
+      assert.is_nil(buf_maparg(panel, lhs, "n"), "panel should not carry review map " .. lhs)
+    end
+  end)
+
+  describe("is_diff_buffer", function()
+    it("matches session diff buffers only", function()
+      local lifecycle = require("codediff.ui.lifecycle")
+      local t = keymaps._test
+      assert.is_true(t.is_diff_buffer(lifecycle, tabpage, diff1))
+      assert.is_true(t.is_diff_buffer(lifecycle, tabpage, diff2))
+      assert.is_false(t.is_diff_buffer(lifecycle, tabpage, panel))
+    end)
+  end)
+end)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes keymap unreliability between `review.nvim` and `codediff.nvim` by scoping review maps to diff panes, routing them through codediff's keymap registry, and warning about custom overlaps at setup.

- Review maps now only apply to diff buffers, leaving explorer/history panels to codediff's own keys.
- Keymap installs go through codediff's session registry, so layout toggles no longer race with review's maps.
- `q` deliberately overrides codediff's quit on diff panes; the help popup and docs now say so explicitly.
- Setup warns when custom review maps overlap codediff's view/conflict role maps, excluding the known `q` override.
- Added tests for buffer scoping, registry integration, conflict detection, and default keymap disjointness against codediff.

<sup>Written for commit 3a5090fcbf4bb5f18fd0c14af3ba4f3a1b326326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/review.nvim/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

